### PR TITLE
Add Python SDK and Data API sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Config files
 environ.sh
 config.py
+iot_config.yaml
+data_access.json
 
 # Certificates
 *.pem

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ as well as the messages received.
 | Description                                          | Command Line          | Python       |
 |------------------------------------------------------|:---------------------:|:------------:|
 | IoT from scratch (Setup IoT environment from command line) | [Sample](./samples/script/iot-from-scratch/) |              |
-| Manage Digital Twins (Create, delete, ...)           | [Sample](./samples/script/manage-dt/) |              |
+| Manage Digital Twins (Create, query, delete). The Python sample demonstrates the use of the OCI Python SDK and the IoT Platform Data API           | [Sample](./samples/script/manage-dt/) | [Sample](./samples/python/manage-dt/) |
 | Publish telemetry (HTTPS - REST API)                 | [Sample](./samples/script/publish-https/) | [Sample](./samples/python/publish-https/)  |
 | Publish telemetry (MQTTS - Secure MQTT)              |                       | [Sample](./samples/python/publish-mqtt/)  |
 | Publish telemetry (WSS - Secure MQTT over WebSocket) |                       | [Sample](./samples/python/publish-websockets/)  |

--- a/samples/python/manage-dt/README.md
+++ b/samples/python/manage-dt/README.md
@@ -1,0 +1,263 @@
+# OCI IoT Platform Device Workflow Demo Python script
+
+Sample Python application to create, query, and delete devices to illustrate the use of the
+[OCI Python SDK](https://docs.oracle.com/en-us/iaas/tools/python/latest/), in particular
+the bindings for the [OCI IoT Platform](https://docs.oracle.com/en-us/iaas/tools/python/latest/api/iot.html)
+as well as the [ORDS API](https://docs.oracle.com/iaas/tools/internet-of-things/data-api/index.html)
+for data access.
+
+The `manage-dt` package consists of several source files and can be installed with `pip`
+(see below). If you are only interested in looking at the sample code:
+
+- [mdt_iot_oci.py](./manage_dt/mdt_iot_oci.py) contains the calls to the OCI Python SDK
+- [mdt_iot_data.py](./manage_dt/mdt_iot_data.py) focuses on the ORDS data API
+
+## Prerequisites
+
+The application assumes that you have already set up an OCI IoT Platform environment in
+your OCI tenancy:
+
+- an OCI IoT Domain Group and Domain
+- OCI Vault secrets and/or OCI Certificates for your device credentials
+- a Confidential Application to issue tokens for querying telemetry via ORDS. This step is
+  only required for the `query` command of `manage-dt`.
+
+## Installation
+
+To install and run the `manage-dt` application, you need **Python 3.12 or higher**.
+
+We recommend installing in an isolated virtual environment:
+
+```sh
+# Ensure Python 3.12+ is available
+python3 --version
+
+# Create and activate a new virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Upgrade pip (optional but recommended)
+python -m pip install --upgrade pip
+
+# Install the application and dependencies
+pip install .
+```
+
+You can now use the console command:
+
+```sh
+manage-dt --help
+```
+
+## Configuration file
+
+The application gets its configuration from the `iot_config.yaml` file in the `data`
+directory. Copy the `iot_config.distr.yaml` template to `iot_config.yaml` and enter the
+required data.
+
+### `iot` section
+
+This section is for the IoT Platform parameters:
+
+- `domain_id`: the OCID of your IoT Domain
+
+### `identity` section
+
+This section contains the OCI Identity parameters and relates to the OAuth configuration
+needed to access the ORDS API.
+
+This section is needed for the `query` command of the application.
+
+- `app_client_id` and `app_client_secret`: the Confidential Application Client ID and
+  Secret. You can find these in the OCI Console: `Identity > Domain > Your Domain >
+  Integrated App > OAuth`
+- `user` and `password`: the OCI User and Password in the Identity Domain where the
+  Confidential Application is created. Typically, this will be your OCI username and
+  password, unless the application is created in a separate Identity Domain.
+
+### `environ` section
+
+Define here environment variables which can be referenced in the `digital_twins`
+section. The sample data defines a `device_key` variable, used to name your digital
+twins and avoid duplicate names if different users run the same sample application.
+It also defines `auth_id`, the OCID of a Vault Secret containing the password for the device.
+
+### `digital_twins` section
+
+Describes the Digital Twins that can be managed by the application. The sample data
+provides 3 different digital twins:
+
+- `unstructured`: a Digital Twin with unstructured telemetry
+- `default-adapter`: a Digital Twin with structured telemetry using the default Adapter
+- `custom-adapter`: a Digital Twin with structured telemetry with a custom Adapter
+
+You can use these definitions as-is, customize them, or create your own Digital Twin
+definitions.
+
+For each Digital Twin, you must have:
+
+- `device_name`: the name of the device
+- `external_key`: the username the device will use to authenticate
+- `auth_id`: the OCID of a Vault Secret containing the password for the device
+  (Basic authentication) or the OCID of a Certificate for the device (Certificate
+  authentication)
+
+These parameters are sufficient for a Digital Twin with unstructured telemetry.
+
+Additionally, for a Digital Twin with structured telemetry using the default Adapter, you
+also need to provide a model:
+
+- `model_name`: the Digital Twin Model Identifier (DTMI) for your model
+- `model_description`: a plain text description of the model
+- `model_dtdl`: the name of a file containing the model definition (relative to the data
+  directory)
+- `adapter_name`: name for the adapter that will be generated
+
+Finally, for a Digital Twin with structured telemetry with a custom Adapter you will need
+to provide the Adapter definition:
+
+- `adapter_name`: the name of the Adapter
+- `adapter_envelope`: the name of a file containing the inbound envelope definition
+  (relative to the data directory)
+- `adapter_routes`: the name of a file containing the inbound routes definition (relative
+  to the data directory)
+
+The sample definitions in this repository are for an Environmental Sensor reporting two
+temperatures in degrees Celsius, pressure in hectoPascals, and relative humidity in
+percent.
+
+Note that while the OCI CLI uses hyphen-separated words for the Adapter definitions, the
+API uses camelCase notation. For example, `envelope-mapping` for the OCI CLI becomes
+`envelopeMapping` when using the Python SDK or the API.
+
+**Note:** The structured telemetry defined in this script is based on the payload sent by
+an [M5Stack CoreS3](https://docs.m5stack.com/en/core/CoreS3) device with an
+[Env-III](https://docs.m5stack.com/en/unit/envIII) environmental sensor.  
+The expected payload is:
+
+```json
+{
+  "sht_temperature": 23.8,
+  "qmp_temperature": 24.4,
+  "humidity": 56.1,
+  "pressure": 1012.2,
+  "count": 5479
+}
+```
+
+This payload can be emulated by the various sample scripts in this repository.
+
+## Usage
+
+```text
+$ Usage: manage-dt [OPTIONS] COMMAND [ARGS]...
+
+  Manage Digital Twins.
+
+  Sample application to create/query/delete Digital Twins for the OCI Iot
+  Platform.
+
+Options:
+  -v, --verbose                   Verbose mode
+  -d, --debug                     Debug mode
+  --profile TEXT                  The profile in the config file to load.
+                                  [default: wim-iot-fra]
+  --auth [api_key|instance_principal|resource_principal]
+                                  The type of auth to use for the API request.
+                                  [default: api_key]
+  --data-dir DIRECTORY            Data directory  [default: ./data]
+  --iot-config-file FILE          The path to the IoT config file.  [default:
+                                  iot_config.yaml]
+  --version                       Show the version and exit.
+  --help                          Show this message and exit.
+
+Commands:
+  create  Create a new Digital Twin.
+  delete  Delete a Digital Twin.
+  query   Query recent data for a Digital Twin.
+```
+
+The `verbose`/`debug` options control the verbosity of the tool.
+
+The `profile` and `auth` options are similar to those used with the OCI CLI. Similarly,
+they can be set with environment variables: `OCI_CLI_PROFILE` and `OCI_CLI_AUTH`
+respectively.
+
+`data-dir` allows you to specify the location of the data directory, and `iot-config-file`
+can be used to specify an alternative configuration file.
+
+The script supports three basic commands:
+
+- `create`: creates the Digital Twin (with the Model and Adapter if applicable)
+- `query`: queries the content of the Digital Twin (structured telemetry) as well as the
+  Raw Data, Historized Data, and Rejected Data using the ORDS Data API. By default, data
+  for the last 5 minutes is retrieved. You can use the `last-minutes` parameter to
+  specify a different duration.
+- `delete`: deletes the Digital Twin (with the Model and Adapter if applicable)
+
+## Sample session
+
+```text
+$ manage-dt --debug create custom-adapter 
+2025-09-18 20:30:59,503 - DEBUG    - cli.py           - Loading configuration
+2025-09-18 20:30:59,505 - DEBUG    - mdt_oci.py       - OCI authentication: Config file
+2025-09-18 20:30:59,506 - DEBUG    - config.py        - Config file found at ~/.oci/config
+2025-09-18 20:30:59,575 - INFO     - mdt_iot_oci.py   - Create Digital Twin Model 'dtmi:com:oracle:pvhd:m5:env:cstm;1'
+2025-09-18 20:30:59,795 - INFO     - mdt_iot_oci.py   - Digital Twin Model created
+2025-09-18 20:30:59,798 - INFO     - mdt_iot_oci.py   - Create custom Digital Twin Adapter 'pvhd-m5-env-cstm-adapter'
+2025-09-18 20:31:01,116 - INFO     - mdt_iot_oci.py   - Digital Twin Adapter created
+2025-09-18 20:31:01,116 - INFO     - mdt_iot_oci.py   - Create Digital Twin Instance pvhd-m5-env-cstm-01 - Structured Telemetry with custom Adapter
+2025-09-18 20:31:02,947 - INFO     - mdt_iot_oci.py   - Digital Twin Instance created
+$ # Send some data and query:
+$ manage-dt --debug query custom-adapter
+2025-09-18 20:32:39,566 - DEBUG    - cli.py           - Loading configuration
+2025-09-18 20:32:39,569 - DEBUG    - mdt_oci.py       - OCI authentication: Config file
+2025-09-18 20:32:39,569 - DEBUG    - config.py        - Config file found at ~/.oci/config
+2025-09-18 20:32:40,356 - INFO     - mdt_iot_oci.py   - Digital Twin Instance retrieved
+2025-09-18 20:32:40,357 - INFO     - mdt_iot_oci.py   - Query Digital Twin Instance 'custom-adapter'
+2025-09-18 20:32:40,556 - INFO     - mdt_iot_oci.py   - Digital Twin Instance content retrieved
+╭────────────────────────────────────────── Digital Twin Instance content ────────────────────────────╮
+│ {'humidity': 73, 'count': 2, 'pressure': 1023, 'sht_temperature': 22.3, 'qmp_temperature': 22.1}    │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────╯
+2025-09-18 20:32:40,573 - DEBUG    - mdt_iot_data.py  - Using cached data access configuration and token
+         Recent raw data - 2 record(s)          
+┏━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ Id  ┃ Time received (UTC)         ┃ Endpoint ┃
+┡━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ 535 │ 2025-09-18T18:32:28.847244Z │ iot/pvhd │
+│ 536 │ 2025-09-18T18:32:34.621067Z │ iot/pvhd │
+└─────┴─────────────────────────────┴──────────┘
+              Recent historized data - 4 record(s)              
+┏━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━┓
+┃ Id   ┃ Time observed (UTC)         ┃ Content path    ┃ Value ┃
+┡━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━┩
+│ 1852 │ 2025-09-18T18:32:28.847244Z │ sht_temperature │ 22.3  │
+│ 1853 │ 2025-09-18T18:32:28.847244Z │ humidity        │ 73    │
+│ 1854 │ 2025-09-18T18:32:28.847244Z │ pressure        │ 1023  │
+│ 1855 │ 2025-09-18T18:32:28.847244Z │ qmp_temperature │ 22.1  │
+└──────┴─────────────────────────────┴─────────────────┴───────┘
+                             Recent rejected data - 1 record(s)                              
+┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Id ┃ Time received (UTC)         ┃ Endpoint ┃ Reason code ┃ Reason message                ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ 48 │ 2025-09-18T18:32:34.621067Z │ iot/pvhd │ 500         │ Normalization output is empty │
+└────┴─────────────────────────────┴──────────┴─────────────┴───────────────────────────────┘
+$ manage-dt --debug delete custom-adapter
+2025-09-18 20:33:33,603 - DEBUG    - cli.py           - Loading configuration
+2025-09-18 20:33:33,605 - DEBUG    - mdt_oci.py       - OCI authentication: Config file
+2025-09-18 20:33:33,605 - DEBUG    - config.py        - Config file found at ~/.oci/config
+2025-09-18 20:33:33,673 - INFO     - mdt_iot_oci.py   - Delete Digital Twin Instance 'custom-adapter'
+2025-09-18 20:33:34,514 - INFO     - mdt_iot_oci.py   - Digital Twin Instance deleted
+2025-09-18 20:33:34,514 - INFO     - mdt_iot_oci.py   - Delete Digital Twin Adapter 'pvhd-m5-env-cstm-adapter'
+2025-09-18 20:33:35,434 - INFO     - mdt_iot_oci.py   - Digital Twin Adapter deleted
+2025-09-18 20:33:35,434 - INFO     - mdt_iot_oci.py   - Delete Digital Twin Model 'dtmi:com:oracle:pvhd:m5:env:cstm;1'
+2025-09-18 20:33:36,204 - INFO     - mdt_iot_oci.py   - Digital Twin Model deleted
+$ 
+```
+
+## Caveat
+
+As we do not store OCIDs of the IoT objects created, identification is done based on
+_Display Name_. However, as with most OCI resources, the _Display Name_ is not a unique
+identifier! While it is not a recommended practice, it is possible to have two Digital
+Twins with the same name. This sample application might not handle such cases properly.

--- a/samples/python/manage-dt/data/iot_config.distr.yaml
+++ b/samples/python/manage-dt/data/iot_config.distr.yaml
@@ -1,0 +1,63 @@
+# Manage-dt: Configuration file.
+#
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+iot:
+  # IoT Domain OCID
+  domain_id: <IoT Domain OCID>
+
+identity:
+  # Confidential Application Client ID and Secret
+  # You can find these in the OCI Console:
+  # Identity > Domain > Your Domain > Integrated App > OAuth
+  app_client_id: <Application Client Id>
+  app_client_secret: <Application Client Secret>
+
+  # The OCI user and password in the Identity Domain where the Confidential
+  # Application is created. (Typically, this will be your OCI username and password,
+  # unless the application is created in a separate Identity domain.)
+  user: <OCI User>
+  password: <OCI Password>
+
+# Declare "environment variables" which can be used for the digital twins definitions below
+environ:
+  # A short ID used to uniquely identify the resources created
+  device_key: <My Id>
+  # The OCID of a Vault Secret which can be used for all Digital Twins
+  auth_id: <Secret OCID>
+
+digital_twins:
+  unstructured:
+    # Unstructured Digital Twin
+    # You can send any telemetry to this Digital Twin.
+    device_name: ${device_key}-01
+    external_key: ${device_key}-01
+    auth_id: ${auth_id}
+
+  default-adapter:
+    # M5 Stack with EnvIII sensor - Structured telemetry with Adapter in default format
+    # Payload should match the expected telemetry format as described by the model.
+    device_name: ${device_key}-m5-env-dflt-01
+    model_name: dtmi:com:oracle:${device_key}:m5:env:dflt;1
+    model_description: M5 with EnvIII sensors (${device_key}-default)
+    model_dtdl: m5_model_default.json
+    adapter_name: ${device_key}-m5-env-dflt-adapter
+    external_key: ${device_key}-m5-env-dflt-01
+    auth_id: ${auth_id}
+
+  custom-adapter:
+    # M5 Stack with EnvIII sensor - Structured telemetry with Adapter in custom format
+    # Payload should match the expected telemetry format as described by the adapter.
+    device_name: ${device_key}-m5-env-cstm-01
+    model_name: dtmi:com:oracle:${device_key}:m5:env:cstm;1
+    model_description: M5 with EnvIII sensors (${device_key}-custom)
+    model_dtdl: m5_model_custom.json
+    adapter_name: ${device_key}-m5-env-cstm-adapter
+    adapter_envelope: m5_adapter_envelope.json
+    adapter_routes: m5_adapter_routes.json
+    external_key: ${device_key}-m5-env-cstm-01
+    auth_id: ${auth_id}

--- a/samples/python/manage-dt/data/m5_adapter_envelope.json
+++ b/samples/python/manage-dt/data/m5_adapter_envelope.json
@@ -1,0 +1,17 @@
+{
+  "envelopeMapping": {
+    "timeObserved": "$.time"
+  },
+  "referenceEndpoint": "iot/environ",
+  "referencePayload": {
+    "data": {
+      "count": 0,
+      "humidity": 0.0,
+      "pressure": 0.0,
+      "qmp_temperature": 0.0,
+      "sht_temperature": 0.0,
+      "time": 0
+    },
+    "dataFormat": "JSON"
+  }
+}

--- a/samples/python/manage-dt/data/m5_adapter_routes.json
+++ b/samples/python/manage-dt/data/m5_adapter_routes.json
@@ -1,0 +1,20 @@
+[
+  {
+    "condition": "${endpoint(1) == \"iot\"}",
+    "description": "Environment data",
+    "payloadMapping": {
+      "$.count": "$.count",
+      "$.humidity": "$.humidity",
+      "$.pressure": "$.pressure",
+      "$.qmp_temperature": "$.qmp_temperature",
+      "$.sht_temperature": "$.sht_temperature"
+    }
+  },
+  {
+    "condition": "*",
+    "description": "Default condition",
+    "payloadMapping": {
+      "$.system": "$"
+    }
+  }
+]

--- a/samples/python/manage-dt/data/m5_model_custom.json
+++ b/samples/python/manage-dt/data/m5_model_custom.json
@@ -1,0 +1,53 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:historization;1",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
+  ],
+  "@id": "placeholder",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": ["Telemetry", "Historized", "Temperature"],
+      "name": "sht_temperature",
+      "displayName": "SHT Temperature",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": ["Telemetry", "Historized", "Temperature"],
+      "name": "qmp_temperature",
+      "displayName": "QMP Temperature",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": ["Telemetry", "Historized", "RelativeHumidity"],
+      "name": "humidity",
+      "displayName": "Relative Humidity",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": ["Telemetry", "Historized", "Pressure"],
+      "name": "pressure",
+      "displayName": "Pressure",
+      "schema": "double",
+      "unit": "millibar"
+    },
+    {
+      "@type": ["Telemetry"],
+      "name": "count",
+      "displayName": "Message Count",
+      "schema": "integer"
+    },
+    {
+      "@type": ["Telemetry", "Historized"],
+      "name": "system",
+      "displayName": "System Message",
+      "schema": {
+        "@type": "Object"
+      }
+    }
+  ]
+}

--- a/samples/python/manage-dt/data/m5_model_default.json
+++ b/samples/python/manage-dt/data/m5_model_default.json
@@ -1,0 +1,45 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:historization;1",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
+  ],
+  "@id": "placeholder",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": ["Telemetry", "Historized", "Temperature"],
+      "name": "sht_temperature",
+      "displayName": "SHT Temperature",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": ["Telemetry", "Historized", "Temperature"],
+      "name": "qmp_temperature",
+      "displayName": "QMP Temperature",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": ["Telemetry", "Historized", "RelativeHumidity"],
+      "name": "humidity",
+      "displayName": "Relative Humidity",
+      "schema": "double",
+      "unit": "percent"
+    },
+    {
+      "@type": ["Telemetry", "Historized", "Pressure"],
+      "name": "pressure",
+      "displayName": "Pressure",
+      "schema": "double",
+      "unit": "millibar"
+    },
+    {
+      "@type": ["Telemetry"],
+      "name": "count",
+      "displayName": "Message Count",
+      "schema": "integer"
+    }
+  ]
+}

--- a/samples/python/manage-dt/manage_dt/__init__.py
+++ b/samples/python/manage-dt/manage_dt/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+"""
+Manage Digital Twins for the OCI IoT Platform.
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version("manage_dt")
+except Exception:
+    __version__ = "unknown"

--- a/samples/python/manage-dt/manage_dt/cli.py
+++ b/samples/python/manage-dt/manage_dt/cli.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Manage Digital Twins for the OCI IoT Platform.
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+import logging
+import os
+import pathlib
+import string
+from typing import Any
+
+import click
+import manage_dt
+import yaml
+
+from . import mdt_constants, mdt_iot_oci, mdt_oci
+
+LOGGER_FMT = "{asctime} - {levelname:8} - {filename:16} - {message}"
+logger = logging.getLogger(__name__)
+
+
+def load_config(config_file: pathlib.Path) -> dict:
+    """Load and substitute values in the config file.
+
+    Args:
+        config_file (pathlib.Path): Path to the configuration YAML file.
+
+    Returns:
+        dict: Loaded and processed configuration.
+    """
+    logger.debug("Loading configuration")
+    with open(config_file, "r") as fp:
+        config = yaml.safe_load(fp)
+    environ = config["environ"]
+
+    for digital_twin_data in config["digital_twins"].values():
+        for key, value in digital_twin_data.items():
+            digital_twin_data[key] = string.Template(value).safe_substitute(environ)
+    return config
+
+
+def validate_digital_twin(
+    ctx: click.Context, param: click.Parameter, value: Any
+) -> Any:
+    """Validate Digital Twin argument for Click commands.
+
+    Args:
+        ctx (click.Context): Click context.
+        param (click.Parameter): Click parameter.
+        value (Any): Argument value.
+
+    Returns:
+        Any: Validated argument.
+
+    Raises:
+        click.BadParameter: If value is not a valid Digital Twin.
+    """
+    digital_twin_list = list(ctx.obj["iot_config"]["digital_twins"].keys())
+    if value not in digital_twin_list:
+        raise click.BadParameter(f"must be one of: {digital_twin_list}")
+    return value
+
+
+@click.group()
+@click.option("-v", "--verbose", is_flag=True, help="Verbose mode")
+@click.option("-d", "--debug", is_flag=True, help="Debug mode")
+@click.option(
+    "--profile",
+    help="The profile in the config file to load.",
+    default=os.getenv("OCI_CLI_PROFILE", "DEFAULT"),
+    show_default=True,
+)
+@click.option(
+    "--auth",
+    type=click.Choice(["api_key", "instance_principal", "resource_principal"]),
+    help="The type of auth to use for the API request.",
+    default=os.getenv("OCI_CLI_AUTH", "api_key"),
+    show_default=True,
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        path_type=pathlib.Path,
+    ),
+    default=mdt_constants.DEFAULT_DATA_DIR,
+    help="Data directory",
+    show_default=True,
+)
+@click.option(
+    "--iot-config-file",
+    type=click.Path(exists=False, dir_okay=False, path_type=pathlib.Path),
+    default=mdt_constants.DEFAULT_IOT_CONFIG,
+    help="The path to the IoT config file.",
+    show_default=True,
+)
+@click.version_option(version=manage_dt.__version__)
+@click.pass_context
+def cli(
+    ctx: click.Context,
+    verbose: bool,
+    debug: bool,
+    profile: str,
+    auth: str,
+    data_dir: pathlib.Path,
+    iot_config_file: pathlib.Path,
+):
+    """Manage Digital Twins.
+
+    Sample application to create/query/delete Digital Twins for the OCI Iot Platform.
+
+    \f
+    Args:
+        ctx (click.Context): Click context object.
+        verbose (bool): Enable verbose mode.
+        debug (bool): Enable debug mode.
+        profile (str): OCI config profile name.
+        auth (str): OCI authentication type.
+        data_dir (pathlib.Path): Data directory path.
+        iot_config_file (pathlib.Path): IoT config filename.
+
+    Raises:
+        click.BadParameter: If IoT config file is invalid.
+    """  # noqa: D301
+    # Validate iot_config_file
+    iot_config_file = data_dir / iot_config_file
+    if not iot_config_file.is_file():
+        raise click.BadParameter(
+            f"File '{iot_config_file}' does not exist.",
+            param_hint="'--iot-config-file'",
+        )
+    if not os.access(iot_config_file, os.R_OK):
+        raise click.BadParameter(
+            f"File '{iot_config_file}' is not readable.",
+            param_hint="'--iot-config-file'",
+        )
+
+    # Setup logging
+    log_level = logging.WARNING
+    if verbose:
+        log_level = logging.INFO
+    if debug:
+        log_level = logging.DEBUG
+        # Silence third party libraries
+        logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
+        logging.getLogger("oci._vendor.urllib3.connectionpool").setLevel(logging.INFO)
+        logging.getLogger("oci.util").setLevel(logging.INFO)
+        logging.getLogger("oci.circuit_breaker").setLevel(logging.INFO)
+    logging.basicConfig(level=log_level, format=LOGGER_FMT, style="{")
+
+    # Preserve context
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+    ctx.obj["debug"] = debug
+    ctx.obj["data_dir"] = data_dir
+    ctx.obj["iot_config"] = load_config(iot_config_file)
+    config, signer = mdt_oci.get_oci_config(profile=profile, auth=auth)
+    ctx.obj["oci_config"] = {"config": config, "signer": signer}
+
+
+@cli.command()
+@click.argument(
+    "digital_twin", type=str, required=True, callback=validate_digital_twin, nargs=1
+)
+@click.pass_context
+def create(ctx: click.Context, digital_twin: str):
+    """Create a new Digital Twin.
+
+    For Digital Twins with telemetry in structured format, Model and Adapter
+    will be created as well.
+
+    \f
+    Args:
+        ctx (click.Context): Click context.
+        digital_twin (str): Name of the Digital Twin.
+    """  # noqa: D301
+    mdt_iot_oci.create_digital_twin(
+        digital_twin=digital_twin,
+        iot_config=ctx.obj["iot_config"],
+        data_dir=ctx.obj["data_dir"],
+        config=ctx.obj["oci_config"]["config"],
+        signer=ctx.obj["oci_config"]["signer"],
+    )
+
+
+@cli.command()
+@click.option(
+    "--last-minutes",
+    "-l",
+    type=int,
+    help="The query will show data received in the 'last-minutes'.",
+    default=mdt_constants.DEFAULT_LAST_MINUTES,
+    show_default=True,
+)
+@click.argument(
+    "digital_twin", type=str, required=True, callback=validate_digital_twin, nargs=1
+)
+@click.pass_context
+def query(ctx, last_minutes, digital_twin):
+    """Query recent data for a Digital Twin.
+
+    For Digital Twins with telemetry in structured format, the Digital Twin Content
+    is retrieved using the Python SDK.
+    Raw data, historized data and rejected data are retrieved using the
+    IoT Platform Data API.
+
+    \f
+    Args:
+        ctx (click.Context): Click context.
+        last_minutes (int): Time window for the query.
+        digital_twin (str): Name of the Digital Twin.
+    """  # noqa: D301
+    mdt_iot_oci.query_digital_twin(
+        digital_twin=digital_twin,
+        last_minutes=last_minutes,
+        iot_config=ctx.obj["iot_config"],
+        data_dir=ctx.obj["data_dir"],
+        config=ctx.obj["oci_config"]["config"],
+        signer=ctx.obj["oci_config"]["signer"],
+    )
+
+
+@cli.command()
+@click.argument(
+    "digital_twin", type=str, required=True, callback=validate_digital_twin, nargs=1
+)
+@click.pass_context
+def delete(ctx: click.Context, digital_twin: str):
+    """Delete a Digital Twin.
+
+    For Digital Twins with telemetry in structured format, Model and Adapter
+    will be deleted as well.
+
+    \f
+    Args:
+        ctx (click.Context): Click context.
+        digital_twin (str): Name of the Digital Twin.
+    """  # noqa: D301
+    mdt_iot_oci.delete_digital_twin(
+        digital_twin=digital_twin,
+        iot_config=ctx.obj["iot_config"],
+        config=ctx.obj["oci_config"]["config"],
+        signer=ctx.obj["oci_config"]["signer"],
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/samples/python/manage-dt/manage_dt/mdt_constants.py
+++ b/samples/python/manage-dt/manage_dt/mdt_constants.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Manage-dt: Constants.
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+DEFAULT_DATA_DIR = "./data"
+DEFAULT_IOT_CONFIG = "iot_config.yaml"
+
+DATA_ACCESS_CACHE = "data_access.json"
+TOKEN_GRACE_SECONDS = 60
+DEFAULT_LAST_MINUTES = 5

--- a/samples/python/manage-dt/manage_dt/mdt_iot_data.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_data.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Manage-dt: OCI IoT interactions (data API).
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+from datetime import datetime, timedelta, timezone
+import json
+import logging
+import pathlib
+import time
+from typing import Optional
+
+from oci import exceptions as oci_exceptions, iot as oci_iot
+import requests
+import requests.auth
+
+from . import mdt_constants
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_data_access_parameters(
+    client: oci_iot.IotClient, iot_config: dict, data_dir: pathlib.Path
+) -> Optional[dict]:
+    """Get and cache data API access parameters.
+
+    This function creates/updates a file to cache data. The file contains:
+        {
+            "iot_domain_id":
+            "oauth_endpoint":
+            "iot_data_endpoint":
+            "token":
+            "expires":
+        }
+    The cache is invalidated if the iot_domain_id changes.
+    On the first call, the IoT Domain and Domain Group are queried to retrieve the
+    OAuth endpoint and the IoT data endpoint.
+    On subsequent calls, the token is refreshed if it is about to expire.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        iot_config (dict): IoT configuration.
+        data_dir (pathlib.Path): Data directory.
+
+    Returns:
+        Optional[dict]: Data access parameters or None.
+    """
+    iot_domain_id = iot_config["iot"]["domain_id"]
+    now = time.time()
+    data_access = None
+    data_access_cache_path = data_dir / mdt_constants.DATA_ACCESS_CACHE
+    if data_access_cache_path.exists():
+        with open(data_access_cache_path, "r") as fp:
+            data_access = json.load(fp)
+        if (
+            data_access["expires"] > now + mdt_constants.TOKEN_GRACE_SECONDS
+            and data_access["iot_domain_id"] == iot_domain_id
+        ):
+            logger.debug("Using cached data access configuration and token")
+            return data_access
+
+    # Either there is no data_access file or the token is about to expire
+    if not data_access or data_access["iot_domain_id"] != iot_domain_id:
+        logger.debug("Retrieving data access configuration")
+        data_access = {"iot_domain_id": iot_domain_id}
+        try:
+            response = client.get_iot_domain(iot_domain_id=iot_domain_id)
+        except oci_exceptions.ServiceError as exc:
+            logger.error("Cannot get IoT Domain")
+            logger.error("  Status : %d - %s", exc.status, exc.code)
+            logger.error("  Message: %s", exc.message)
+            return None
+        if not response or response.status != 200:
+            logger.error(
+                "Cannot retrieve IoT Domain - %s",
+                response.status if response else None,
+            )
+            return None
+        identity_domain = response.data.db_allowed_identity_domain_host
+        if not identity_domain:
+            logger.error("ORDS Data access has not been configured for this IoT Domain")
+            return None
+        iot_domain_short_id = response.data.device_host.split(".")[0]
+        iot_domain_group_id = response.data.iot_domain_group_id
+        try:
+            response = client.get_iot_domain_group(
+                iot_domain_group_id=iot_domain_group_id
+            )
+        except oci_exceptions.ServiceError as exc:
+            logger.error("Cannot get IoT Domain Group")
+            logger.error("  Status : %d - %s", exc.status, exc.code)
+            logger.error("  Message: %s", exc.message)
+            return None
+        if not response or response.status != 200:
+            logger.error(
+                "Cannot retrieve IoT Domain Group - %s",
+                response.status if response else None,
+            )
+            return None
+        iot_domain_group_data_host = response.data.data_host
+        iot_domain_group_short_id = iot_domain_group_data_host.split(".")[0]
+        data_access["iot_data_endpoint"] = (
+            f"https://{iot_domain_group_data_host}/ords/{iot_domain_short_id}/20250531"
+        )
+        data_access["oauth_endpoint"] = f"https://{identity_domain}/oauth2/v1/token"
+        data_access["scope"] = f"/{iot_domain_group_short_id}/iot/{iot_domain_short_id}"
+
+    logger.debug("Getting OAuth access token")
+    r = requests.post(
+        url=data_access["oauth_endpoint"],
+        auth=requests.auth.HTTPBasicAuth(
+            iot_config["identity"]["app_client_id"],
+            iot_config["identity"]["app_client_secret"],
+        ),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "scope": data_access["scope"],
+            "grant_type": "password",
+            "username": iot_config["identity"]["user"],
+            "password": iot_config["identity"]["password"],
+        },
+    )
+    if r.status_code != requests.codes.ok:
+        logger.error("Unable to get OAuth access token")
+        logger.error("  Status : %s", r.status_code)
+        logger.error("  Message: %s", r.text)
+        return None
+
+    # returns: {'access_token': '...',  'token_type': 'Bearer', 'expires_in': 3600}
+    oauth_token = r.json()
+    data_access["token"] = oauth_token["access_token"]
+    data_access["expires"] = int(now + oauth_token["expires_in"])
+    with open(data_access_cache_path, "w") as fp:
+        json.dump(data_access, fp, indent=2)
+    logger.debug("Data access configuration retrieved and saved")
+    return data_access
+
+
+def get_recent_data(
+    data_access: dict,
+    last_minutes: int,
+    digital_twin_instance_id: str,
+    endpoint: str,
+    time_field: str,
+) -> Optional[list]:
+    """Query recent data for a digital twin from the data API.
+
+    Args:
+        data_access (dict): Data access parameters.
+        last_minutes (int): Minutes back to query.
+        digital_twin_instance_id (str): Digital Twin instance ID.
+        endpoint (str): Data endpoint.
+        time_field (str): Time field to filter (time_received or time_observed).
+
+    Returns:
+        Optional[list]: List of queried items or None.
+    """
+    recent_time = datetime.now(timezone.utc) - timedelta(minutes=last_minutes)
+    recent_time_iso = recent_time.isoformat().replace("+00:00", "Z")
+    query = {
+        "$and": [
+            {"digital_twin_instance_id": digital_twin_instance_id},
+            {time_field: {"$gte": {"$date": recent_time_iso}}},
+        ]
+    }
+    r = requests.get(
+        url=f"{data_access['iot_data_endpoint']}/{endpoint}",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {data_access['token']}",
+        },
+        params={
+            "q": json.dumps(query),
+            "limit": 100,
+            "offset": 0,
+        },
+    )
+    if r.status_code != requests.codes.ok:
+        logger.error("Unable to query data API")
+        logger.error("  Status : %s", r.status_code)
+        logger.error("  Message: %s", r.text)
+        return None
+    return r.json()["items"]
+
+
+def get_recent_raw_data(
+    data_access: dict, digital_twin_instance_id: str, last_minutes: int
+) -> Optional[list]:
+    """Query recent raw data for a digital twin.
+
+    Args:
+        data_access (dict): Data access parameters.
+        digital_twin_instance_id (str): Digital Twin instance ID.
+        last_minutes (int): Minutes back to query.
+
+    Returns:
+        Optional[list]: List of raw data or None.
+    """
+    return get_recent_data(
+        data_access=data_access,
+        last_minutes=last_minutes,
+        digital_twin_instance_id=digital_twin_instance_id,
+        endpoint="rawData",
+        time_field="time_received",
+    )
+
+
+def get_recent_historized_data(
+    data_access: dict, digital_twin_instance_id: str, last_minutes: int
+) -> Optional[list]:
+    """Query recent historized data for a digital twin.
+
+    Args:
+        data_access (dict): Data access parameters.
+        digital_twin_instance_id (str): Digital Twin instance ID.
+        last_minutes (int): Minutes back to query.
+
+    Returns:
+        Optional[list]: List of historized data or None.
+    """
+    return get_recent_data(
+        data_access=data_access,
+        last_minutes=last_minutes,
+        digital_twin_instance_id=digital_twin_instance_id,
+        endpoint="historizedData",
+        time_field="time_observed",
+    )
+
+
+def get_recent_rejected_data(
+    data_access: dict, digital_twin_instance_id: str, last_minutes: int
+) -> Optional[list]:
+    """Query recent rejected data for a digital twin.
+
+    Args:
+        data_access (dict): Data access parameters.
+        digital_twin_instance_id (str): Digital Twin instance ID.
+        last_minutes (int): Minutes back to query.
+
+    Returns:
+        Optional[list]: List of rejected data or None.
+    """
+    return get_recent_data(
+        data_access=data_access,
+        last_minutes=last_minutes,
+        digital_twin_instance_id=digital_twin_instance_id,
+        endpoint="rejectedData",
+        time_field="time_received",
+    )

--- a/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""
+Manage-dt: OCI IoT interactions.
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+import json
+import logging
+import pathlib
+from typing import Optional
+
+from oci import exceptions as oci_exceptions, iot as oci_iot
+from rich.console import Console
+from rich.panel import Panel
+from rich.pretty import Pretty
+from rich.table import Table
+
+from . import mdt_iot_data
+
+logger = logging.getLogger(__name__)
+
+
+def create_digital_twin_model(
+    client: oci_iot.IotClient,
+    display_name: str,
+    description: Optional[str],
+    iot_domain_id: str,
+    spec_dtdl: dict,
+) -> Optional[str]:
+    """Create a Digital Twin Model.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        display_name (str): Model name.
+        description (Optional[str]): Description.
+        iot_domain_id (str): IoT Domain OCID.
+        spec_dtdl (dict): DTDL spec.
+
+    Returns:
+        Optional[str]: Model OCID or None.
+    """
+    digital_twin_model = oci_iot.models.CreateDigitalTwinModelDetails(
+        display_name=display_name,
+        description=description,
+        iot_domain_id=iot_domain_id,
+        spec=spec_dtdl,
+    )
+    ocid = None
+    try:
+        response = client.create_digital_twin_model(digital_twin_model)
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot create Digital Twin Model")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+    else:
+        if response and response.status == 200:
+            logger.info("Digital Twin Model created")
+            ocid = response.data.id
+        else:
+            logger.error(
+                "Cannot create Digital Twin Model: %s",
+                response.status if response else None,
+            )
+    return ocid
+
+
+def delete_digital_twin_model_by_spec_uri(
+    client: oci_iot.IotClient,
+    spec_uri: str,
+    iot_domain_id: str,
+) -> bool:
+    """Delete a Digital Twin Model by spec URI.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        spec_uri (str): Model spec URI.
+        iot_domain_id (str): IoT Domain OCID.
+
+    Returns:
+        bool: True if deleted, else False.
+    """
+    response = client.list_digital_twin_models(
+        iot_domain_id=iot_domain_id,
+        digital_twin_model_spec_uri_starts_with=spec_uri,
+        lifecycle_state="ACTIVE",
+    )
+    if not response or response.status != 200:
+        logger.error(
+            "Cannot get Digital Twin Model list - %s",
+            response.status if response else None,
+        )
+        return False
+    if len(response.data.items) == 0:
+        logger.error("Digital Twin Model does not exist")
+        return False
+    try:
+        response = client.delete_digital_twin_model(
+            digital_twin_model_id=response.data.items[0].id
+        )
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot delete Digital Twin Model")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+        return False
+    if response and response.status == 204:
+        logger.info("Digital Twin Model deleted")
+        return True
+    else:
+        logger.error(
+            "Cannot delete Digital Twin Model - %s",
+            response.status if response else None,
+        )
+        return False
+
+
+def create_digital_twin_adapter(
+    client: oci_iot.IotClient,
+    display_name: str,
+    description: Optional[str],
+    iot_domain_id: str,
+    digital_twin_model_spec_uri: str,
+    inbound_envelope: Optional[dict],
+    inbound_routes: Optional[dict],
+) -> Optional[str]:
+    """Create a Digital Twin Adapter.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        display_name (str): Adapter name.
+        description (Optional[str]): Description.
+        iot_domain_id (str): IoT Domain OCID.
+        digital_twin_model_spec_uri (str): Model spec URI.
+        inbound_envelope (Optional[dict]): Envelope data.
+        inbound_routes (Optional[dict]): Routes data.
+
+    Returns:
+        Optional[str]: Adapter OCID or None.
+    """
+    digital_twin_adapter = oci_iot.models.CreateDigitalTwinAdapterDetails(
+        display_name=display_name,
+        description=description,
+        iot_domain_id=iot_domain_id,
+        digital_twin_model_spec_uri=digital_twin_model_spec_uri,
+        inbound_envelope=inbound_envelope,
+        inbound_routes=inbound_routes,
+    )
+    ocid = None
+    try:
+        response = client.create_digital_twin_adapter(digital_twin_adapter)
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot create Digital Twin Adapter")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+    else:
+        if response and response.status == 200:
+            logger.info("Digital Twin Adapter created")
+            ocid = response.data.id
+        else:
+            logger.error(
+                "Cannot create Digital Twin Adapter: %s",
+                response.status if response else None,
+            )
+    return ocid
+
+
+def delete_digital_twin_adapter_by_name(
+    client: oci_iot.IotClient,
+    display_name: str,
+    iot_domain_id: str,
+) -> bool:
+    """Delete a Digital Twin Adapter by name.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        display_name (str): Adapter name.
+        iot_domain_id (str): IoT Domain OCID.
+
+    Returns:
+        bool: True if deleted, else False.
+    """
+    response = client.list_digital_twin_adapters(
+        iot_domain_id=iot_domain_id,
+        display_name=display_name,
+        lifecycle_state="ACTIVE",
+    )
+    if not response or response.status != 200:
+        logger.error(
+            "Cannot get Digital Twin Adapter list - %s",
+            response.status if response else None,
+        )
+        return False
+    if len(response.data.items) == 0:
+        logger.error("Digital Twin Adapter does not exist")
+        return False
+    elif len(response.data.items) > 1:
+        logger.error("Multiple Digital Twin Adapters exist with the same name")
+        return False
+    try:
+        response = client.delete_digital_twin_adapter(
+            digital_twin_adapter_id=response.data.items[0].id
+        )
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot delete Digital Twin Adapter")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+        return False
+    if response and response.status == 204:
+        logger.info("Digital Twin Adapter deleted")
+        return True
+    else:
+        logger.error(
+            "Cannot delete Digital Twin Adapter - %s",
+            response.status if response else None,
+        )
+        return False
+
+
+def create_digital_twin_instance(
+    client: oci_iot.IotClient,
+    display_name: str,
+    description: Optional[str],
+    iot_domain_id: str,
+    digital_twin_adapter_id: Optional[str],
+    external_key: str,
+    auth_id: str,
+) -> Optional[str]:
+    """Create a Digital Twin Instance.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        display_name (str): Instance name.
+        description (Optional[str]): Description.
+        iot_domain_id (str): IoT Domain OCID.
+        digital_twin_adapter_id (Optional[str]): Adapter OCID.
+        external_key (str): Device key.
+        auth_id (str): Auth ID.
+
+    Returns:
+        Optional[str]: Instance OCID or None.
+    """
+    digital_twin_instance = oci_iot.models.CreateDigitalTwinInstanceDetails(
+        display_name=display_name,
+        description=description,
+        iot_domain_id=iot_domain_id,
+        digital_twin_adapter_id=digital_twin_adapter_id,
+        external_key=external_key,
+        auth_id=auth_id,
+    )
+    ocid = None
+    try:
+        response = client.create_digital_twin_instance(digital_twin_instance)
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot create Digital Twin Instance")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+    else:
+        if response and response.status == 200:
+            logger.info("Digital Twin Instance created")
+            ocid = response.data.id
+        else:
+            logger.error(
+                "Cannot create Digital Twin Instance: %s",
+                response.status if response else None,
+            )
+    return ocid
+
+
+def get_digital_twin_instance_by_name(
+    client: oci_iot.IotClient,
+    display_name: str,
+    iot_domain_id: str,
+) -> Optional[oci_iot.models.DigitalTwinInstance]:
+    """Get a Digital Twin Instance by name.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        display_name (str): Instance name.
+        iot_domain_id (str): IoT Domain OCID.
+
+    Returns:
+        Optional[oci_iot.models.DigitalTwinInstance]: The instance or None.
+    """
+    response = client.list_digital_twin_instances(
+        iot_domain_id=iot_domain_id,
+        display_name=display_name,
+        lifecycle_state="ACTIVE",
+    )
+    if not response or response.status != 200:
+        logger.error(
+            "Cannot get Digital Twin Instance list - %s",
+            response.status if response else None,
+        )
+        return None
+    if len(response.data.items) == 0:
+        logger.error("Digital Twin Instance does not exist")
+        return None
+    elif len(response.data.items) > 1:
+        logger.error("Multiple Digital Twins exist with the same name")
+        return None
+    try:
+        response = client.get_digital_twin_instance(
+            digital_twin_instance_id=response.data.items[0].id
+        )
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot get Digital Twin Instance")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+        return None
+    if response and response.status == 200:
+        logger.info("Digital Twin Instance retrieved")
+        return response.data
+    else:
+        logger.error(
+            "Cannot retrieve Digital Twin Instance - %s",
+            response.status if response else None,
+        )
+        return None
+
+
+def get_digital_twin_instance_content(
+    client: oci_iot.IotClient,
+    digital_twin_instance_id: str,
+) -> Optional[dict]:
+    """Get content of a Digital Twin Instance.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        digital_twin_instance_id (str): Instance OCID.
+
+    Returns:
+        Optional[dict]: Instance content or None.
+    """
+    try:
+        response = client.get_digital_twin_instance_content(
+            digital_twin_instance_id=digital_twin_instance_id
+        )
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot get Digital Twin Instance content")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+        return None
+    if response and response.status == 200:
+        logger.info("Digital Twin Instance content retrieved")
+        return response.data
+    else:
+        logger.error(
+            "Cannot retrieve Digital Twin Instance content - %s",
+            response.status if response else None,
+        )
+        return None
+
+
+def delete_digital_twin_instance_by_name(
+    client: oci_iot.IotClient,
+    display_name: str,
+    iot_domain_id: str,
+) -> bool:
+    """Delete a Digital Twin Instance by name.
+
+    Args:
+        client (oci_iot.IotClient): OCI IoT client.
+        display_name (str): Instance name.
+        iot_domain_id (str): Domain OCID.
+
+    Returns:
+        bool: True if deleted, else False.
+    """
+    response = client.list_digital_twin_instances(
+        iot_domain_id=iot_domain_id,
+        display_name=display_name,
+        lifecycle_state="ACTIVE",
+    )
+    if not response or response.status != 200:
+        logger.error(
+            "Cannot get Digital Twin Instance list - %s",
+            response.status if response else None,
+        )
+        return False
+    if len(response.data.items) == 0:
+        logger.error("Digital Twin Instance does not exist")
+        return False
+    try:
+        response = client.delete_digital_twin_instance(
+            digital_twin_instance_id=response.data.items[0].id
+        )
+    except oci_exceptions.ServiceError as exc:
+        logger.error("Cannot delete Digital Twin Instance")
+        logger.error("  Status : %d - %s", exc.status, exc.code)
+        logger.error("  Message: %s", exc.message)
+        return False
+    if response and response.status == 204:
+        logger.info("Digital Twin Instance deleted")
+        return True
+    else:
+        logger.error(
+            "Cannot delete Digital Twin Instance - %s",
+            response.status if response else None,
+        )
+        return False
+
+
+def create_digital_twin(
+    digital_twin: str,
+    iot_config: dict,
+    data_dir: pathlib.Path,
+    config: dict,
+    signer: dict,
+) -> None:
+    """Create a new Digital Twin with related resources (Model and Adapter).
+
+    Args:
+        digital_twin (str): Name of Digital Twin.
+        iot_config (dict): IoT configuration.
+        data_dir (pathlib.Path): Data directory.
+        config (dict): OCI config.
+        signer (dict): OCI signer.
+    """
+    digital_twin_config = iot_config["digital_twins"][digital_twin]
+    client = oci_iot.IotClient(config=config, **signer)
+
+    if "model_dtdl" not in digital_twin_config:
+        description = f"{digital_twin_config['device_name']} - Unstructured Telemetry"
+        digital_twin_adapter_id = None
+    else:
+        logger.info("Create Digital Twin Model '%s'", digital_twin_config["model_name"])
+        with open(data_dir / digital_twin_config["model_dtdl"], "r") as fp:
+            spec_dtdl = json.load(fp)
+        spec_dtdl["@id"] = digital_twin_config["model_name"]
+        ocid = create_digital_twin_model(
+            client=client,
+            display_name=digital_twin_config["model_name"],
+            description=digital_twin_config["model_description"],
+            iot_domain_id=iot_config["iot"]["domain_id"],
+            spec_dtdl=spec_dtdl,
+        )
+        if not ocid:
+            return
+        if "adapter_envelope" not in digital_twin_config:
+            description = f"{digital_twin_config['device_name']} - Structured Telemetry with default Adapter"
+            logger.info(
+                "Create default Digital Twin Adapter '%s'",
+                digital_twin_config["adapter_name"],
+            )
+            ocid = create_digital_twin_adapter(
+                client=client,
+                display_name=digital_twin_config["adapter_name"],
+                description=f"Default Adapter for {digital_twin_config['model_name']}",
+                iot_domain_id=iot_config["iot"]["domain_id"],
+                digital_twin_model_spec_uri=digital_twin_config["model_name"],
+                inbound_envelope=None,
+                inbound_routes=None,
+            )
+        else:
+            description = f"{digital_twin_config['device_name']} - Structured Telemetry with custom Adapter"
+            logger.info(
+                "Create custom Digital Twin Adapter '%s'",
+                digital_twin_config["adapter_name"],
+            )
+            with open(data_dir / digital_twin_config["adapter_envelope"], "r") as fp:
+                inbound_envelope = json.load(fp)
+            with open(data_dir / digital_twin_config["adapter_routes"], "r") as fp:
+                inbound_routes = json.load(fp)
+            ocid = create_digital_twin_adapter(
+                client=client,
+                display_name=digital_twin_config["adapter_name"],
+                description=f"Default Adapter for {digital_twin_config['model_name']}",
+                iot_domain_id=iot_config["iot"]["domain_id"],
+                digital_twin_model_spec_uri=digital_twin_config["model_name"],
+                inbound_envelope=inbound_envelope,
+                inbound_routes=inbound_routes,
+            )
+        if not ocid:
+            return
+        digital_twin_adapter_id = ocid
+
+    logger.info("Create Digital Twin Instance %s", description)
+    create_digital_twin_instance(
+        client=client,
+        display_name=digital_twin_config["device_name"],
+        description=description,
+        iot_domain_id=iot_config["iot"]["domain_id"],
+        digital_twin_adapter_id=digital_twin_adapter_id,
+        external_key=digital_twin_config["external_key"],
+        auth_id=digital_twin_config["auth_id"],
+    )
+
+
+def query_digital_twin(
+    digital_twin: str,
+    last_minutes: int,
+    iot_config: dict,
+    data_dir: pathlib.Path,
+    config: dict,
+    signer: dict,
+) -> None:
+    """Query and print data for a Digital Twin.
+
+    Args:
+        digital_twin (str): Name of Digital Twin.
+        last_minutes (int): Lookback period in minutes.
+        iot_config (dict): IoT configuration.
+        data_dir (pathlib.Path): Data directory.
+        config (dict): OCI config.
+        signer (dict): OCI signer.
+    """
+    digital_twin_config = iot_config["digital_twins"][digital_twin]
+    client = oci_iot.IotClient(config=config, **signer)
+
+    digital_twin_instance = get_digital_twin_instance_by_name(
+        client=client,
+        display_name=digital_twin_config["device_name"],
+        iot_domain_id=iot_config["iot"]["domain_id"],
+    )
+    if not digital_twin_instance:
+        return
+
+    digital_twin_instance_id: str = digital_twin_instance.id  # type: ignore
+    console = Console()
+    if "model_dtdl" in digital_twin_config:
+        # Digital Twin content is only available for structured telemetry
+        logger.info("Query Digital Twin Instance '%s'", digital_twin)
+        digital_twin_instance_content = get_digital_twin_instance_content(
+            client=client, digital_twin_instance_id=digital_twin_instance_id
+        )
+        console.print(
+            Panel(
+                Pretty(digital_twin_instance_content),
+                title="Digital Twin Instance content",
+            )
+        )
+
+    data_access = mdt_iot_data.get_data_access_parameters(
+        client=client, iot_config=iot_config, data_dir=data_dir
+    )
+    if not data_access:
+        return
+
+    raw_data = mdt_iot_data.get_recent_raw_data(
+        data_access=data_access,
+        digital_twin_instance_id=digital_twin_instance_id,
+        last_minutes=last_minutes,
+    )
+    if raw_data is not None:
+        table = Table(
+            "Id",
+            "Time received (UTC)",
+            "Endpoint",
+            title=f"Recent raw data - {len(raw_data)} record(s)",
+        )
+        for record in raw_data:
+            table.add_row(
+                str(record["id"]), record["time_received"], record["endpoint"]
+            )
+        console.print(table)
+
+    historized_data = mdt_iot_data.get_recent_historized_data(
+        data_access=data_access,
+        digital_twin_instance_id=digital_twin_instance_id,
+        last_minutes=last_minutes,
+    )
+    if historized_data is not None:
+        table = Table(
+            "Id",
+            "Time observed (UTC)",
+            "Content path",
+            "Value",
+            title=f"Recent historized data - {len(historized_data)} record(s)",
+        )
+        for record in historized_data:
+            table.add_row(
+                str(record["id"]),
+                record["time_observed"],
+                record["content_path"],
+                str(record["value"]),
+            )
+        console.print(table)
+
+    rejected_data = mdt_iot_data.get_recent_rejected_data(
+        data_access=data_access,
+        digital_twin_instance_id=digital_twin_instance_id,
+        last_minutes=last_minutes,
+    )
+    if rejected_data is not None:
+        table = Table(
+            "Id",
+            "Time received (UTC)",
+            "Endpoint",
+            "Reason code",
+            "Reason message",
+            title=f"Recent rejected data - {len(rejected_data)} record(s)",
+        )
+        for record in rejected_data:
+            table.add_row(
+                str(record["id"]),
+                record["time_received"],
+                record["endpoint"],
+                str(record["reason_code"]),
+                record["reason_message"],
+            )
+        console.print(table)
+
+
+def delete_digital_twin(
+    digital_twin: str, iot_config: dict, config: dict, signer: dict
+) -> None:
+    """Delete a Digital Twin and all related OCI resources (Model and Adapter).
+
+    Args:
+        digital_twin (str): Name of Digital Twin.
+        iot_config (dict): IoT configuration.
+        config (dict): OCI config.
+        signer (dict): OCI signer.
+    """
+    digital_twin_config = iot_config["digital_twins"][digital_twin]
+    client = oci_iot.IotClient(config=config, **signer)
+
+    logger.info("Delete Digital Twin Instance '%s'", digital_twin)
+    delete_digital_twin_instance_by_name(
+        client=client,
+        display_name=digital_twin_config["device_name"],
+        iot_domain_id=iot_config["iot"]["domain_id"],
+    )
+
+    if "model_dtdl" in digital_twin_config:
+        logger.info(
+            "Delete Digital Twin Adapter '%s'", digital_twin_config["adapter_name"]
+        )
+        delete_digital_twin_adapter_by_name(
+            client=client,
+            display_name=digital_twin_config["adapter_name"],
+            iot_domain_id=iot_config["iot"]["domain_id"],
+        )
+        logger.info("Delete Digital Twin Model '%s'", digital_twin_config["model_name"])
+        delete_digital_twin_model_by_spec_uri(
+            client=client,
+            spec_uri=digital_twin_config["model_name"],
+            iot_domain_id=iot_config["iot"]["domain_id"],
+        )

--- a/samples/python/manage-dt/manage_dt/mdt_oci.py
+++ b/samples/python/manage-dt/manage_dt/mdt_oci.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Manage-dt: OCI Helpers.
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+import logging
+import os
+from typing import Tuple
+
+from oci import config as oci_config
+from oci.auth import signers as oci_auth_signers
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_oci_config(
+    profile: str = os.getenv("OCI_CLI_PROFILE", "DEFAULT"),
+    auth: str = os.getenv("OCI_CLI_AUTH", "api_key"),
+) -> Tuple[dict, dict]:
+    """Obtain OCI configuration and signer.
+
+    Determines the appropriate OCI configuration and authentication signer
+    based on the provided profile and authentication method. Supports
+    authentication via API Key (either key content from environment variables
+    or configuration file), instance principal, or resource principal.
+
+    Args:
+        profile (str, optional): The OCI CLI profile name to use. Defaults to
+            the value of the environment variable "OCI_CLI_PROFILE" or "DEFAULT".
+        auth (str, optional): The authentication method to use. Supported
+            values are "api_key", "instance_principal", and "resource_principal".
+            Defaults to the value of the environment variable "OCI_CLI_AUTH"
+            or "api_key".
+
+    Returns:
+        Tuple[dict, dict]: A tuple containing:
+            - config (dict): OCI configuration details, or empty dict for
+              principal-based authentication.
+            - signer (dict): Signer details or empty dict if not required.
+
+    Raises:
+        ValueError: If an unsupported authentication scheme is provided.
+        oci_exceptions.ClientError: If the configuration is invalid (config
+            file not found, invalid profile, missing resource for principals, ...)
+
+    """
+    match auth:
+        case "api_key":
+            if os.getenv("OCI_CLI_KEY_CONTENT"):
+                logger.debug("OCI authentication: Environment")
+                signer = {}
+                config = {
+                    "user": os.getenv("OCI_CLI_USER"),
+                    "key_content": os.getenv("OCI_CLI_KEY_CONTENT"),
+                    "fingerprint": os.getenv("OCI_CLI_FINGERPRINT"),
+                    "tenancy": os.getenv("OCI_CLI_TENANCY"),
+                    "region": os.getenv("OCI_CLI_REGION"),
+                }
+                oci_config.validate_config(config)
+            else:
+                logger.debug("OCI authentication: Config file")
+                signer = {}
+                config = oci_config.from_file(profile_name=profile)
+        case "instance_principal":
+            logger.debug("OCI authentication: Instance Principal")
+            signer = {
+                "signer": oci_auth_signers.InstancePrincipalsSecurityTokenSigner(),
+            }
+            config = {}
+        case "resource_principal":
+            logger.debug("OCI authentication: Resource Principals")
+            signer = {
+                "signer": oci_auth_signers.get_resource_principals_signer(),
+            }
+            config = {}
+        case _:
+            raise ValueError(f"unsupported auth scheme {auth}")
+    return config, signer

--- a/samples/python/manage-dt/setup.py
+++ b/samples/python/manage-dt/setup.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+Manage Digital Twins for the OCI IoT Platform.
+
+Copyright (c) 2025 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+import os
+
+from setuptools import find_packages, setup
+
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="manage_dt",
+    version="0.0.2",
+    description="Manage Digital Twins sample script",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Programming Language :: Python :: 3",
+        "Operating System :: POSIX :: Linux",
+    ],
+    packages=find_packages(),
+    python_requires=">=3.12",
+    install_requires=[
+        "click~=8.2.0",
+        "oci~=2.158",
+        "PyYAML~=6.0.0",
+        "requests~=2.32.0",
+        "rich~=13.0.0",
+    ],
+    extras_require={
+        "test": [
+            "flake8",
+            "flake8-comprehensions",
+            "flake8-docstrings",
+            "flake8-import-order",
+            "pep8-naming",
+            "pydocstyle",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "manage-dt=manage_dt.cli:cli",
+        ],
+    },
+)

--- a/samples/script/manage-dt/environ.distr.sh
+++ b/samples/script/manage-dt/environ.distr.sh
@@ -20,12 +20,11 @@ IOT_DOMAIN_ID="ocid1.iotdomain...."
 # Optional: ORDS Data Access
 ###
 
-# The Domain Group Short ID is the first element of the dataHost property of
-# the Domain Group.
+# The Domain Group dataHost.
 # You can retrieve it with the following command:
 # oci iot domain-group get --iot-domain-group-id <IoT Domain Group OCID> \
 #   --query 'data."data-host"' --raw-output
-DOMAIN_GROUP_SHORT_ID=
+DOMAIN_GROUP_DATA_HOST=
 
 # The Domain Short ID is the first element of the deviceHost property of the
 # Domain.
@@ -52,9 +51,8 @@ IAM_PASSWORD=
 ###
 # IoT OCI Endpoints - Do not change
 ###
-DOMAIN_REGION=us-ashburn-1
-if [[ -n ${DOMAIN_GROUP_SHORT_ID} && -n ${DOMAIN_SHORT_ID} && -n ${IAM_DOMAIN_URL} ]]; then
-    IOT_DATA_ENDPOINT="https://${DOMAIN_GROUP_SHORT_ID}.data.iot.${DOMAIN_REGION}.oci.oraclecloud.com/ords/${DOMAIN_SHORT_ID}/20250531"
+if [[ -n ${DOMAIN_GROUP_DATA_HOST} && -n ${DOMAIN_SHORT_ID} && -n ${IAM_DOMAIN_URL} ]]; then
+    IOT_DATA_ENDPOINT="https://${DOMAIN_GROUP_DATA_HOST}/ords/${DOMAIN_SHORT_ID}/20250531"
     OAUTH_ENDPOINT="${IAM_DOMAIN_URL}/oauth2/v1/token"
 fi
 


### PR DESCRIPTION
Add `manage-dt` Python sample to illustrate use of the OCI Python SDK and the Data API for the IoT Platform.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>
