### PR TITLE
feat: :sparkles: Added command data, OCI settings, and domain group and domain data

### DIFF
--- a/apex/dashboard/Change_Log.md
+++ b/apex/dashboard/Change_Log.md
@@ -1,0 +1,30 @@
+# IoT Explorer - Release Notes
+
+## September 16th 2025
+
+### New Features
+
+- Inclusion of command data throughout the application
+- Copy button added to OCIDs
+- Settings page added for user tenancy information
+- IoT Platform domain group and domain information added
+
+### Changes
+
+- Direct link from IoT Platform object listings to recent activity
+
+### Bug Fixes
+
+- Report column names and order consistancy
+
+## August 25th 2025
+
+### Inital Release
+
+Features
+
+- Traffic monitoring dashboard
+- Listing of IoT Platform objects (models, adapters, and instances)
+- Reports of Raw Data, Errors, and Historized data
+- Dynamic tree structure of IoT Platform objects, their relationships, and most
+recent data collected

--- a/apex/dashboard/README.md
+++ b/apex/dashboard/README.md
@@ -13,6 +13,27 @@ This APEX application serves as a dashboard for monitoring IoT devices and messa
 Documentation about creating APEX users can be found in the
 [APEX Administration Guide](https://docs.oracle.com/en/database/oracle/apex/24.2/aeadm/managing-users-across-an-application-express-instance.html#GUID-CE23292D-05D1-4E79-BF40-8BC31E74E6C8).
 
+### Optional
+
+It is recommended that you create an OCI user and group that IoT Explorer can use to
+access OCI REST APIs. However, any user with sufficient access will suffice.
+
+Begin by creating an OCI user group, then a user assigned to that group. Once the
+user is created, an email will be sent to the specified address. Follow the link and
+complete account activation.
+
+While logged in as the new user, go to the user profile and set up an API key for
+the user. Save the private key and the configuration information once the key is
+created.
+
+Then, as the admin-level user, create a new policy and set the following.
+
+```text
+Allow group <grp_name> to manage iot-family in compartment <cmp_name>
+Allow group <grp_name> to manage iot-domain-family in compartment <cmp_name>
+Allow group <grp_name> to manage iot-digital-twin-family in compartment <cmp_name>
+```
+
 ## Setup
 
 After completing your IoT Platform setup, you should be able to access your APEX
@@ -58,7 +79,7 @@ The following will walk you through the installation of the IoT Explorer
 application.
 
 1. Click "Import".
-2. Select the F102.sql file.
+2. Select the F103.sql file.
 3. Click the "Next" button.
 4. Set the "Parsing Schema" to your workspace (e.g., ****************__wksp).
 5. You may either reuse application number 105 or allow APEX to auto-assign a new
@@ -87,3 +108,8 @@ as well as telemetry sent to the platform (raw, rejected, and historized data).
 
 The "IoT Tree" page organizes the IoT objects and telemetry received by each object
 in a hierarchy starting with models, next adapters, then digital twins.
+
+The 'Settings' page allows you to enter a user's credentials and information
+about your tenancy.  This information, along with OCI policies allows the
+application to make the REST API calls to the IoT service. Any features requiring a
+value that has not been set will display a message to that effect.

--- a/apex/dashboard/f102.sql
+++ b/apex/dashboard/f102.sql
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c5f9b94a70c72e607855a61c445502f0fd893d9f49657ce3c77dd5eaddf3b21
-size 694063
+oid sha256:1868ccc55ad17d6418092bb9c7968d2f9a0be4bffea2ca46395e71b0863dc7d0
+size 843644


### PR DESCRIPTION

# Description

Command data has has been integrated into all monitoring pages. A dedicated settings page has been introduced to store configuration details necessary for seamless communication with Oracle Cloud Infrastructure (OCI) services, thereby streamlining integration and functionality. The application now displays the domain group and domain information associated with the installation domain, enhancing transparency and facilitating easier management.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
