### PR TITLE
Improve IoT Python samples: richer manage-dt data queries, keyed command/response topics, and sample consistency updates

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Install pre-commit-terraform dependencies
         env:
           TFLINT_VERSION: 'v0.59.1'
-          TRIVY_VERSION: '0.67.0'
+          TRIVY_VERSION: '0.69.3'
         shell: bash
         run: |
           echo "Installing tflint..."

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -31,9 +31,9 @@ jobs:
           python-version: '3.12'
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.0'
+          node-version: '22'
 
       - name: Add ~/.local/bin directory
         shell: bash

--- a/samples/python/command-response/README.md
+++ b/samples/python/command-response/README.md
@@ -11,8 +11,12 @@ Note that the OCI IoT Platform only supports MQTT Secure (MQTTS) on port 8883.
 
 The `command-response.py` script will establish an MQTT connection with the OCI IoT
 Platform and send telemetry data on a regular basis.
-It will listen for commands by subscribing to topics ending in `/cmd` and acknowledge
-by sending a response.
+It uses a configurable base endpoint and derives:
+
+- telemetry: `<iot_base_endpoint>/telemetry`
+- commands: `<iot_base_endpoint>/cmd/<key>`
+- responses: `<iot_base_endpoint>/rsp/<key>`
+
 The script will terminate when it receives a _shutdown_ command or a keyboard interrupt (Control-C).
 
 Notes:
@@ -67,7 +71,9 @@ The `time` field is optional, this can be specified in the configuration file (s
 Copy `config.distr.py` to `config.py` and set the following variables:
 
 - `iot_device_host`: The Device Host for your IoT Domain.
-- `iot_endpoint`: The  MQTT topic for your telemetry.
+- `iot_base_endpoint`: The MQTT base endpoint.
+  The script derives telemetry (`<base>/telemetry`), command
+  (`<base>/cmd/<key>`) and response (`<base>/rsp/<key>`) topics from this value.
 - `message_delay`: The delay in seconds between messages.
 - `client_id`: The client ID used for the MQTT connection (typically the name of your device).
 - `ca_certs`: The path to the CA certificate for the OCI IoT Platform.  
@@ -107,9 +113,9 @@ While the script is running, send raw commands using the OCI CLI -- e.g.:
 ```shell
 oci iot digital-twin-instance invoke-raw-json-command \
   --digital-twin-instance-id <DigitalTwin OCID> \
-  --request-endpoint "iot/v1/cmd" \
+  --request-endpoint "<iot_base_endpoint>/cmd/<key>" \
   --request-duration "PT10M" \
-  --response-endpoint "iot/v1/rsp" \
+  --response-endpoint "<iot_base_endpoint>/rsp/<key>" \
   --response-duration "PT10M" \
   --request-data '{
     "hello": "world"
@@ -129,13 +135,13 @@ Sending message #4
 Sending message #5
 Sending message #6
 Sending message #7
-Received command on iot/v1/cmd: {"hello":"world"}
-Sending ack to iot/v1/rsp: {"status": "acknowledged", "time": 1753456852150}
+Received command on iot/v1/cmd/pvhd-01: {"hello":"world"}
+Sending ack to iot/v1/rsp/pvhd-01: {"status": "acknowledged", "time": 1753456852150}
 Sending message #8
 Sending message #9
-Received command on iot/v1/cmd: {"shutdown":true}
+Received command on iot/v1/cmd/pvhd-01: {"shutdown":true}
 Shutdown command received. Preparing to exit...
-Sending ack to iot/v1/rsp: {"status": "acknowledged", "time": 1753456874872}
+Sending ack to iot/v1/rsp/pvhd-01: {"status": "acknowledged", "time": 1753456874872}
 Waiting 2 seconds to process possible /cmd messages...
 Terminated
 $

--- a/samples/python/command-response/command-response.py
+++ b/samples/python/command-response/command-response.py
@@ -3,7 +3,7 @@
 """
 Command-response scenario for the OCI IoT Platform.
 
-Copyright (c) 2025 Oracle and/or its affiliates.
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at
 https://oss.oracle.com/licenses/upl
 

--- a/samples/python/command-response/command-response.py
+++ b/samples/python/command-response/command-response.py
@@ -26,6 +26,10 @@ import environmental_sensor_simulator
 import paho.mqtt.client as mqtt
 
 MQTT_PORT = 8883
+IOT_BASE_ENDPOINT = config.iot_base_endpoint.rstrip("/")
+TELEMETRY_TOPIC = f"{IOT_BASE_ENDPOINT}/telemetry"
+COMMAND_TOPIC_PREFIX = f"{IOT_BASE_ENDPOINT}/cmd/"
+RESPONSE_TOPIC_PREFIX = f"{IOT_BASE_ENDPOINT}/rsp/"
 
 
 # Get the current UTC time as an epoch value in microseconds.
@@ -36,8 +40,8 @@ def current_epoch_microseconds():
 # Callback for MQTT connection event.
 def on_connect(client, userdata, flags, reason_code, properties=None):
     print(f"Connected with result code {reason_code}")
-    # Subscribe to all topics ending with /cmd (using '#' and filtering in callback).
-    client.subscribe("#", qos=config.qos)
+    # Subscribe to all command topics: iot/v1/cmd/<key>
+    client.subscribe(f"{COMMAND_TOPIC_PREFIX}#", qos=config.qos)
 
 
 # Command handler thread
@@ -60,8 +64,9 @@ def command_handler():
             print("Shutdown command received. Preparing to exit...")
             state["shutdown_event"].set()  # Signal the telemetry loop to stop.
 
-        # Build corresponding /rsp topic
-        rsp_topic = topic[:-4] + "/rsp"
+        # Build corresponding response topic: iot/v1/rsp/<key>
+        command_key = topic[len(COMMAND_TOPIC_PREFIX) :]
+        rsp_topic = f"{RESPONSE_TOPIC_PREFIX}{command_key}"
         ack_msg = json.dumps(
             {"status": "acknowledged", "time": current_epoch_microseconds()}
         )
@@ -76,7 +81,7 @@ def on_message(client, userdata, message, properties=None):
     topic = message.topic
     payload = message.payload.decode()
     state = userdata
-    if topic.endswith("/cmd"):
+    if topic.startswith(COMMAND_TOPIC_PREFIX):
         command_handler_queue.put((topic, payload, state))
 
 
@@ -130,7 +135,7 @@ try:
     while not state["shutdown_event"].is_set():
         print(f"Sending message #{count}")
         rc_pub = client.publish(
-            topic=config.iot_endpoint,
+            topic=TELEMETRY_TOPIC,
             payload=json.dumps(telemetry.get_telemetry()),
             qos=config.qos,
         )

--- a/samples/python/command-response/config.distr.py
+++ b/samples/python/command-response/config.distr.py
@@ -8,7 +8,7 @@
 iot_device_host = "<Device Host>"
 
 # The MQTT topic.
-iot_endpoint = "iot/v1/mqtt"
+iot_endpoint = "iot/v1/telemetry"
 
 # Delay in seconds between messages.
 message_delay = 10

--- a/samples/python/command-response/config.distr.py
+++ b/samples/python/command-response/config.distr.py
@@ -7,8 +7,12 @@
 #       --query 'data."device-host"' --raw-output
 iot_device_host = "<Device Host>"
 
-# The MQTT topic.
-iot_endpoint = "iot/v1/telemetry"
+# The MQTT base endpoint.
+# The script derives:
+#   telemetry: <iot_base_endpoint>/telemetry
+#   commands:  <iot_base_endpoint>/cmd/<key>
+#   responses: <iot_base_endpoint>/rsp/<key>
+iot_base_endpoint = "iot/v1"
 
 # Delay in seconds between messages.
 message_delay = 10

--- a/samples/python/manage-dt/data/m5_adapter_envelope.json
+++ b/samples/python/manage-dt/data/m5_adapter_envelope.json
@@ -2,7 +2,7 @@
   "envelopeMapping": {
     "timeObserved": "$.time"
   },
-  "referenceEndpoint": "iot/environ",
+  "referenceEndpoint": "iot/v1/telemetry",
   "referencePayload": {
     "data": {
       "count": 0,

--- a/samples/python/manage-dt/data/m5_adapter_routes.json
+++ b/samples/python/manage-dt/data/m5_adapter_routes.json
@@ -1,6 +1,6 @@
 [
   {
-    "condition": "${endpoint(1) == \"iot\"}",
+    "condition": "${endpoint(3) == \"telemetry\"}",
     "description": "Environment data",
     "payloadMapping": {
       "$.count": "$.count",

--- a/samples/python/manage-dt/data/m5_model_custom.json
+++ b/samples/python/manage-dt/data/m5_model_custom.json
@@ -33,7 +33,7 @@
       "name": "pressure",
       "displayName": "Pressure",
       "schema": "double",
-      "unit": "millibar"
+      "unit": "hectopascal"
     },
     {
       "@type": ["Telemetry"],

--- a/samples/python/manage-dt/data/m5_model_default.json
+++ b/samples/python/manage-dt/data/m5_model_default.json
@@ -33,7 +33,7 @@
       "name": "pressure",
       "displayName": "Pressure",
       "schema": "double",
-      "unit": "millibar"
+      "unit": "hectopascal"
     },
     {
       "@type": ["Telemetry"],

--- a/samples/python/manage-dt/manage_dt/mdt_iot_data.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_data.py
@@ -148,6 +148,7 @@ def get_recent_data(
     digital_twin_instance_id: str,
     endpoint: str,
     time_field: str,
+    order_field: str = "id",
 ) -> Optional[list]:
     """Query recent data for a digital twin from the data API.
 
@@ -156,7 +157,9 @@ def get_recent_data(
         last_minutes (int): Minutes back to query.
         digital_twin_instance_id (str): Digital Twin instance ID.
         endpoint (str): Data endpoint.
-        time_field (str): Time field to filter (time_received or time_observed).
+        time_field (str): Time field to filter (for example time_received,
+            time_observed, or time_created).
+        order_field (str): Field name used for descending sort.
 
     Returns:
         Optional[list]: List of queried items or None.
@@ -169,7 +172,7 @@ def get_recent_data(
             {time_field: {"$gte": {"$date": recent_time_iso}}},
         ],
         "$orderby": {
-            "id": "desc",
+            order_field: "desc",
         },
     }
     r = requests.get(
@@ -272,6 +275,96 @@ def get_recent_historized_data(
         endpoint="historizedData",
         time_field="time_observed",
     )
+
+
+def get_recent_raw_command_data(
+    data_access: dict, digital_twin_instance_id: str, last_minutes: int
+) -> Optional[list]:
+    """Query recent raw command data for a digital twin.
+
+    Args:
+        data_access (dict): Data access parameters.
+        digital_twin_instance_id (str): Digital Twin instance ID.
+        last_minutes (int): Minutes back to query.
+
+    Returns:
+        Optional[list]: List of raw command data records or None.
+    """
+    raw_command_data = get_recent_data(
+        data_access=data_access,
+        last_minutes=last_minutes,
+        digital_twin_instance_id=digital_twin_instance_id,
+        endpoint="rawCommandData",
+        time_field="time_created",
+        order_field="time_created",
+    )
+    if raw_command_data is None:
+        return None
+
+    # rawCommandData list does not include request/response payloads.
+    # Query each record by id to retrieve full command details.
+    enriched_data = []
+    for record in raw_command_data:
+        record_id = record["id"]
+        record_details = get_raw_command_data_by_id(
+            data_access=data_access, raw_command_data_id=record_id
+        )
+        if not record_details:
+            enriched_data.append(
+                {
+                    "id": record_id,
+                    "request_endpoint": None,
+                    "request_data": None,
+                    "response_endpoint": None,
+                    "response_data": None,
+                    "time_created": record.get("time_created"),
+                    "time_updated": record.get("time_updated"),
+                    "time_finished": record.get("time_finished"),
+                    "delivery_status": record.get("delivery_status"),
+                }
+            )
+            continue
+        enriched_data.append(
+            {
+                "id": record_details.get("id", record_id),
+                "request_endpoint": record_details.get("request_endpoint"),
+                "request_data": record_details.get("request_data"),
+                "response_endpoint": record_details.get("response_endpoint"),
+                "response_data": record_details.get("response_data"),
+                "time_created": record_details.get("time_created"),
+                "time_updated": record_details.get("time_updated"),
+                "time_finished": record_details.get("time_finished"),
+                "delivery_status": record_details.get("delivery_status"),
+            }
+        )
+    return enriched_data
+
+
+def get_raw_command_data_by_id(
+    data_access: dict, raw_command_data_id: int
+) -> Optional[dict]:
+    """Query one raw command data record by ID from the data API.
+
+    Args:
+        data_access (dict): Data access parameters.
+        raw_command_data_id (int): Raw command data record identifier.
+
+    Returns:
+        Optional[dict]: Raw command data record details, or None if the query fails.
+    """
+    r = requests.get(
+        url=f"{data_access['iot_data_endpoint']}/rawCommandData/{raw_command_data_id}",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {data_access['token']}",
+        },
+    )
+    if r.status_code != requests.codes.ok:
+        logger.error("Unable to query raw command data by ID (%s)", raw_command_data_id)
+        logger.error("  Status : %s", r.status_code)
+        logger.error("  Message: %s", r.text)
+        return None
+    return r.json()
 
 
 def get_recent_rejected_data(

--- a/samples/python/manage-dt/manage_dt/mdt_iot_data.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_data.py
@@ -167,7 +167,10 @@ def get_recent_data(
         "$and": [
             {"digital_twin_instance_id": digital_twin_instance_id},
             {time_field: {"$gte": {"$date": recent_time_iso}}},
-        ]
+        ],
+        "$orderby": {
+            "id": "desc",
+        },
     }
     r = requests.get(
         url=f"{data_access['iot_data_endpoint']}/{endpoint}",

--- a/samples/python/manage-dt/manage_dt/mdt_iot_data.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_data.py
@@ -192,6 +192,31 @@ def get_recent_data(
     return r.json()["items"]
 
 
+def get_raw_data_by_id(data_access: dict, raw_data_id: int) -> Optional[dict]:
+    """Query one raw data record by ID from the data API.
+
+    Args:
+        data_access (dict): Data access parameters.
+        raw_data_id (int): Raw data record identifier.
+
+    Returns:
+        Optional[dict]: Raw data record details, or None if the query fails.
+    """
+    r = requests.get(
+        url=f"{data_access['iot_data_endpoint']}/rawData/{raw_data_id}",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {data_access['token']}",
+        },
+    )
+    if r.status_code != requests.codes.ok:
+        logger.error("Unable to query raw data by ID (%s)", raw_data_id)
+        logger.error("  Status : %s", r.status_code)
+        logger.error("  Message: %s", r.text)
+        return None
+    return r.json()
+
+
 def get_recent_raw_data(
     data_access: dict, digital_twin_instance_id: str, last_minutes: int
 ) -> Optional[list]:
@@ -205,13 +230,26 @@ def get_recent_raw_data(
     Returns:
         Optional[list]: List of raw data or None.
     """
-    return get_recent_data(
+    raw_data = get_recent_data(
         data_access=data_access,
         last_minutes=last_minutes,
         digital_twin_instance_id=digital_twin_instance_id,
         endpoint="rawData",
         time_field="time_received",
     )
+    if raw_data is None:
+        return None
+
+    # rawData does not provide the payload, we need to iterate for each message Id
+    for record in raw_data:
+        record_details = get_raw_data_by_id(
+            data_access=data_access, raw_data_id=record["id"]
+        )
+        if not record_details:
+            record["payload"] = None
+            continue
+        record["payload"] = record_details.get("content")
+    return raw_data
 
 
 def get_recent_historized_data(

--- a/samples/python/manage-dt/manage_dt/mdt_iot_data.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_data.py
@@ -2,7 +2,7 @@
 """
 Manage-dt: OCI IoT interactions (data API).
 
-Copyright (c) 2025 Oracle and/or its affiliates.
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at
 https://oss.oracle.com/licenses/upl
 

--- a/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
@@ -14,7 +14,7 @@ import pathlib
 from typing import Optional
 
 from oci import exceptions as oci_exceptions, iot as oci_iot
-from rich.console import Console
+from rich.console import Console, Group
 from rich.panel import Panel
 from rich.pretty import Pretty
 from rich.table import Table
@@ -582,6 +582,47 @@ def query_digital_twin(
                 str(record["value"]),
             )
         console.print(table)
+
+    raw_command_data = mdt_iot_data.get_recent_raw_command_data(
+        data_access=data_access,
+        digital_twin_instance_id=digital_twin_instance_id,
+        last_minutes=last_minutes,
+    )
+    if raw_command_data is not None:
+        console.print(f"Recent raw command data - {len(raw_command_data)} record(s)")
+        for record in raw_command_data:
+            metadata_table = Table(
+                "Id",
+                "Request endpoint",
+                "Response endpoint",
+                "Time created (UTC)",
+                "Time updated (UTC)",
+                "Time finished (UTC)",
+                "Delivery status",
+            )
+            metadata_table.add_row(
+                str(record["id"]),
+                str(record.get("request_endpoint")),
+                str(record.get("response_endpoint")),
+                str(record.get("time_created")),
+                str(record.get("time_updated")),
+                str(record.get("time_finished")),
+                str(record.get("delivery_status")),
+            )
+            details_table = Table.grid(expand=True)
+            details_table.add_column(no_wrap=True, overflow="ellipsis")
+            details_table.add_row(
+                f"Request data: {json.dumps(record.get('request_data'))}"
+            )
+            details_table.add_row(
+                f"Response data: {json.dumps(record.get('response_data'))}"
+            )
+            console.print(
+                Panel(
+                    Group(metadata_table, details_table),
+                    title=f"Raw command data #{record['id']}",
+                )
+            )
 
     rejected_data = mdt_iot_data.get_recent_rejected_data(
         data_access=data_access,

--- a/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
@@ -2,7 +2,7 @@
 """
 Manage-dt: OCI IoT interactions.
 
-Copyright (c) 2025 Oracle and/or its affiliates.
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at
 https://oss.oracle.com/licenses/upl
 

--- a/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
+++ b/samples/python/manage-dt/manage_dt/mdt_iot_oci.py
@@ -549,11 +549,15 @@ def query_digital_twin(
             "Id",
             "Time received (UTC)",
             "Endpoint",
+            "Payload",
             title=f"Recent raw data - {len(raw_data)} record(s)",
         )
         for record in raw_data:
             table.add_row(
-                str(record["id"]), record["time_received"], record["endpoint"]
+                str(record["id"]),
+                record["time_received"],
+                record["endpoint"],
+                json.dumps(record.get("payload")),
             )
         console.print(table)
 

--- a/samples/python/publish-https/config.distr.py
+++ b/samples/python/publish-https/config.distr.py
@@ -8,7 +8,7 @@
 iot_device_host = "<Device Host>"
 
 # The IoT endpoint can be any value, similar to the MQTT topic.
-iot_endpoint = "iot/v1/http"
+iot_endpoint = "iot/v1/telemetry"
 
 # Format of the "time" field in the payload ("none", "epoch", "iso")
 time_format = "epoch"

--- a/samples/python/publish-mqtt/config.distr.py
+++ b/samples/python/publish-mqtt/config.distr.py
@@ -8,7 +8,7 @@
 iot_device_host = "<Device Host>"
 
 # The MQTT topic.
-iot_endpoint = "iot/v1/mqtt"
+iot_endpoint = "iot/v1/telemetry"
 
 # Number of messages to send and delay in seconds between messages.
 message_count = 10

--- a/samples/python/publish-websockets/config.distr.py
+++ b/samples/python/publish-websockets/config.distr.py
@@ -8,7 +8,7 @@
 iot_device_host = "<Device Host>"
 
 # The MQTT topic.
-iot_endpoint = "iot/v1/mqtt"
+iot_endpoint = "iot/v1/telemetry"
 
 # Number of messages to send and delay in seconds between messages.
 message_count = 10

--- a/samples/script/manage-dt/create_dtc_m5_env.sh
+++ b/samples/script/manage-dt/create_dtc_m5_env.sh
@@ -59,7 +59,7 @@ oci iot digital-twin-model create \
         "name": "pressure",
         "displayName":"Pressure",
         "schema" : "double",
-        "unit" : "millibar"
+        "unit" : "hectopascal"
       },
       {
         "@type": ["Telemetry"],
@@ -88,7 +88,7 @@ oci iot digital-twin-adapter create \
       "envelope-mapping": {
         "time-observed": "$.time"
       },
-      "reference-endpoint": "iot/environ",
+      "reference-endpoint": "iot/v1/telemetry",
       "reference-payload": {
         "data": {
           "count": 0,
@@ -103,7 +103,7 @@ oci iot digital-twin-adapter create \
     }' \
   --inbound-routes '[
       {
-        "condition": "${endpoint(1) == \"iot\"}",
+        "condition": "${endpoint(3) == \"telemetry\"}",
         "description": "Environment data",
         "payload-mapping": {
           "$.count": "$.count",

--- a/samples/script/manage-dt/create_dtd_m5_env.sh
+++ b/samples/script/manage-dt/create_dtd_m5_env.sh
@@ -59,7 +59,7 @@ oci iot digital-twin-model create \
         "name": "pressure",
         "displayName":"Pressure",
         "schema" : "double",
-        "unit" : "millibar"
+        "unit" : "hectopascal"
       },
       {
         "@type": ["Telemetry"],

--- a/samples/script/publish-https/README.md
+++ b/samples/script/publish-https/README.md
@@ -18,7 +18,7 @@ iot_device_host=$(oci iot domain get --iot-domain-id "${iot_domain_id}" \
 ```shell
 iot_device_host="your.device.host"
 # The IoT endpoint can be any value, similar to the MQTT topic.
-iot_endpoint="iot/v1/http"
+iot_endpoint="iot/v1/telemetry"
 # The username is the "externalKey" property of your Digital Twin.
 iot_device_user="your_device_username"
 # The Digital Twin password: this should be the content of the vault secret
@@ -60,7 +60,7 @@ To publish telemetry:
 ```shell
 iot_device_host="your.device.host"
 # The IoT endpoint can be any value, similar to the MQTT topic.
-iot_endpoint="iot/v1/http"
+iot_endpoint="iot/v1/telemetry"
 # Path to your client certificate and key.
 client_cert="client_certificate.pem"
 client_key="client_key.pem"

--- a/samples/terraform/iot-from-scratch/identity.tf
+++ b/samples/terraform/iot-from-scratch/identity.tf
@@ -58,7 +58,7 @@ resource "terraform_data" "oci_identity_domains_setting_signing_cert_public_acce
 resource "oci_identity_domains_app" "this" {
   count = var.configure_ords_data_access && var.create_confidential_app ? 1 : 0
 
-  display_name  = "${local.org_name}-${var.app_id}-app"
+  display_name  = "${local.org_name}-${var.app_id}-app-${local.region_short_name}"
   idcs_endpoint = local.identity_domain_endpoint
   based_on_template {
     value         = "CustomWebAppTemplateId"


### PR DESCRIPTION
## Summary
This merge request bundles updates from the current branch to improve OCI IoT sample usability and observability:

- `manage-dt` now retrieves full payload/details for `rawData` and `rawCommandData` records.
- `command-response` now uses base-topic derived endpoints (`telemetry/cmd/rsp`) and keyed command topics.
- Several sample endpoint defaults were standardized.
- Copyright headers were updated for modified Python scripts.
- Minor Terraform sample fix to include region suffix in app display name.

## Commits included
- `703f497` fix(terraform): include region suffix in app display name
- `f06ec48` fix(manage-dt): sort recent data query by descending id
- `c23459b` feat(manage-dt): include payload in recent raw data output
- `c0fc1c6` feat(manage-dt): add raw command data retrieval helpers
- `9b4341a` fix(samples): standardize telemetry endpoints in IoT examples
- `708e8aa` fix(command-response): derive cmd/rsp topics from base endpoint
- `4669b94` chore(python-samples): update copyright headers for 2026

## Detailed changes

### 1) `samples/python/manage-dt`
- Added per-record detail retrieval for raw data:
  - Query list from `rawData`
  - Query each record via `Get raw data by ID` (`/rawData/{id}`) to display payload content.
- Added recent raw command data section in `query_digital_twin()`:
  - Queries `rawCommandData` by `time_created` (descending).
  - Enriches each record via `Get raw command data by ID` (`/rawCommandData/{id}`).
  - Displays:
    - `id`, `request_endpoint`, `request_data`, `response_endpoint`, `response_data`,
      `time_created`, `time_updated`, `time_finished`, `delivery_status`
- Improved CLI rendering:
  - Replaced overly wide one-line rows with per-record panel layout.
  - Metadata shown in columns; request/response payload shown in dedicated lines.
  - Payload line truncation now uses Rich overflow behavior (width-aware, ellipsis).

### 2) `samples/python/command-response`
- Switched command routing from fixed topics to base-topic derived form:
  - Commands: `<iot_base_endpoint>/cmd/<key>`
  - Responses: `<iot_base_endpoint>/rsp/<key>`
  - Telemetry: `<iot_base_endpoint>/telemetry`
- Updated subscription/filtering logic to match keyed command topics.
- Updated config template and sample docs:
  - Replaced `iot_endpoint` with `iot_base_endpoint` (default: `iot/v1`).
  - README examples updated for keyed cmd/rsp endpoints.

### 3) Other sample consistency updates
- Standardized endpoint defaults across related sample configs/docs.
- Minor Terraform sample update in identity naming.

## Breaking/behavior changes
- `command-response` config now expects `iot_base_endpoint` instead of `iot_endpoint`.
  - Existing local `config.py` files using `iot_endpoint` must be updated.

## Validation performed
- `python3 -m compileall samples/python/manage-dt/manage_dt/mdt_iot_data.py`
- `python3 -m compileall samples/python/manage-dt/manage_dt/mdt_iot_oci.py`
- `python3 -m compileall samples/python/command-response/command-response.py`

All passed.

## Notes for reviewers
- Focus review on:
  - `samples/python/manage-dt/manage_dt/mdt_iot_data.py`
  - `samples/python/manage-dt/manage_dt/mdt_iot_oci.py`
  - `samples/python/command-response/command-response.py`
  - `samples/python/command-response/config.distr.py`
  - `samples/python/command-response/README.md`

## Sign-off

Signed-off-by: Philippe Vanhaesendonck [philippe.vanhaesendonck@oracle.com](mailto:philippe.vanhaesendonck@oracle.com)