### PR TITLE
Add file upload agent sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,16 @@ as well as the messages received.
 | Direct database connection — query telemetry         | [Sample](./samples/script/query-db/) | [Sample](./samples/python/query-db/)  |              |
 | Streaming IoT Platform data (Database queues)        |                       | [Sample](./samples/python/queues/)  |              |
 
-The [`M5Stack CoreS3`](./samples/C/M5Stack/) C sample shows how to connect a
-microcontroller device to the OCI IoT Platform over secure MQTT,
-publish environmental telemetry, handle command-response messages,
-and perform OTA firmware updates triggered through the IoT Platform.
+## End-to-End Samples
+
+- The [`M5Stack CoreS3`](./samples/C/M5Stack/) C sample shows how to connect a
+  microcontroller device to the OCI IoT Platform over secure MQTT,
+  publish environmental telemetry, handle command-response messages,
+  and perform OTA firmware updates triggered through the IoT Platform.
+- The [`File Upload Agent`](./samples/python/file-agent/) Python sample shows how
+  a device can request an upload over MQTT, have a backend agent consume IoT
+  Platform database queue messages, create short-lived Object Storage upload
+  URLs, send responses through raw commands, and run optional post-processing.
 
 ## Documentation
 

--- a/samples/python/file-agent/DTDL/file_agent_model.json
+++ b/samples/python/file-agent/DTDL/file_agent_model.json
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:historization;1"],
+  "@id": "dtmi:com:oracle:iot:fileagent;1",
+  "@type": "Interface",
+  "displayName": "File Agent Interface",
+  "contents": [
+    {
+      "@type": ["Telemetry", "Historized"],
+      "name": "commandDetails",
+      "displayName": "File Command Details",
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "op",
+            "schema": "string",
+            "description": "The operation to perform, e.g., 'prepare-upload'."
+          },
+          {
+            "name": "id",
+            "schema": "string",
+            "description": "A unique identifier for the upload transaction."
+          },
+          {
+            "name": "data",
+            "description": "Operation related data.",
+            "schema": {
+              "@type": "Object"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/samples/python/file-agent/DTDL/uploader_adapter_envelope.json
+++ b/samples/python/file-agent/DTDL/uploader_adapter_envelope.json
@@ -1,0 +1,15 @@
+{
+  "envelopeMapping": {
+    "timeObserved": "$.time"
+  },
+  "referenceEndpoint": "iot/v1/telemetry",
+  "referencePayload": {
+    "data": {
+      "temperature": 22.0,
+      "humidity": 80.0,
+      "pressure": 1024.0,
+      "time": 0
+    },
+    "dataFormat": "JSON"
+  }
+}

--- a/samples/python/file-agent/DTDL/uploader_adapter_routes.json
+++ b/samples/python/file-agent/DTDL/uploader_adapter_routes.json
@@ -1,0 +1,26 @@
+[
+  {
+    "condition": "${endpoint(3) == \"file\" and endpoint(4) == \"cmd\"}",
+    "description": "File upload message",
+    "referencePayload": {
+      "data": {
+        "op": "prepare-upload",
+        "id": "unique-id",
+        "data": {
+          "ttl": 10
+        }
+      },
+      "dataFormat": "JSON"
+    },
+    "payloadMapping": {
+      "$.file.commandDetails": "${ {\"op\": .op, \"id\": .id, \"data\": .data } }"
+    }
+  },
+  {
+    "condition": "*",
+    "description": "Default condition",
+    "payloadMapping": {
+      "$.telemetry": "${.}"
+    }
+  }
+]

--- a/samples/python/file-agent/DTDL/uploader_model.json
+++ b/samples/python/file-agent/DTDL/uploader_model.json
@@ -1,0 +1,24 @@
+{
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:historization;1"
+  ],
+  "@id": "dtmi:com:oracle:iot:uploader;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": ["Telemetry", "Historized"],
+      "name": "telemetry",
+      "displayName": "Telemetry data",
+      "schema": {
+        "@type": "Object"
+      }
+    },
+    {
+      "@type": "Component",
+      "name": "file",
+      "schema": "dtmi:com:oracle:iot:fileagent;1",
+      "displayName": "File upload Component"
+    }
+  ]
+}

--- a/samples/python/file-agent/README.md
+++ b/samples/python/file-agent/README.md
@@ -1,0 +1,342 @@
+# OCI IoT Platform: File Upload Sample
+
+This demonstrates file uploads from an IoT device, represented by a Digital Twin
+Instance (DTI), to OCI Object Storage using the OCI IoT Platform as the communication channel.
+
+This is a simple demo application, not a production-ready file transfer service.
+A production deployment should add stricter authorization and error handling,
+durable state for queued or in-flight work, and database-backed recovery so
+application failures do not lose accepted device requests or processing state.
+
+## High-Level Workflow
+
+![file-agent workflow](./images/file-agent.png)
+
+1. Device: publish a request to the IoT Platform to prepare an upload.
+1. File agent: consume the normalized DTI message from the IoT database (DB/AQ).
+1. File agent: create an OCI Object Storage Pre-Authenticated Request (PAR) and
+   send the upload URL to the device using an OCI IoT raw command.
+1. Device: upload file(s) directly to Object Storage.
+1. Device: publish a message to indicate that the upload is complete.
+1. File agent: delete the PAR.
+1. File agent: run optional post-processing.
+1. File agent: notify the device of post-processing completion.
+
+Command post-processing is queued in the file agent and runs asynchronously.
+
+## Message Protocol
+
+From the device perspective, the protocol uses MQTT JSON messages. The file
+agent consumes device requests from the OCI IoT Platform normalized_data queue using
+DB/AQ and sends responses back to the device using OCI IoT raw commands.
+
+Default endpoints:
+
+- Request topic: `iot/v1/file/cmd` -- the device publishes requests here, and
+  the Digital Twin Adapter route maps these messages to `file.commandDetails`.
+- Response endpoint: `iot/v1/file/rsp` -- the file agent sends raw-command
+  responses here, and the device subscribes to this MQTT topic.
+
+Messages use the following format:
+
+```jsonc
+{
+  "op": "operation",
+  "id": "transaction unique ID",
+  "data": {
+    // Operation-specific data
+  },
+  "code": 200, // Response code (only in response messages)
+  "message": "message" // Response text (only in response messages)
+}
+```
+
+### Prepare Upload
+
+The device asks the file agent to prepare an upload and provides a unique ID for the
+transaction. The request can also include the expected upload URL TTL in minutes.
+
+```json
+{
+  "op": "prepare-upload",
+  "id": "transaction unique ID",
+  "data": {
+    "ttl": 60
+  }
+}
+```
+
+Notes:
+
+- All uploads will go to the same bucket (configurable)
+- For security reasons, upload URLs are ephemeral and the TTL is capped at a
+  configurable maximum value
+
+### Upload Preparation
+
+The file agent:
+
+- Creates a write-only PAR for `<bucket>/<digital twin instance OCID>/<id>/`
+- Sends the upload URL to the device. The URL includes the assigned upload
+  directory because the device does not know its Digital Twin Instance OCID.
+
+```json
+{
+  "op": "prepare-upload",
+  "id": "transaction unique ID",
+  "data": {
+    "upload_url": "upload url with assigned directory"
+  },
+  "code": 200,
+  "message": "Upload prepared"
+}
+```
+
+If an error occurs while preparing the upload:
+
+```json
+{
+  "op": "prepare-upload",
+  "id": "transaction unique ID",
+  "data": {},
+  "code": 500,
+  "message": "error message"
+}
+```
+
+### Upload
+
+The device:
+
+- Uploads file(s)
+- Informs the file agent with an optional command to run:
+
+```jsonc
+{
+  "op": "complete-upload",
+  "id": "transaction unique ID",
+  "data": {
+    "command": "command name", // Alias for the command to run (optional)
+    "parameters": {
+      "artifacts": [ "artifact" ]
+    }
+  }
+}
+```
+
+If the device is unable to upload or wants to abort the upload transaction, it
+should still send a `complete-upload` message to release the PAR.
+
+### Process Artifacts
+
+The file agent:
+
+- Deletes the PAR
+- Acknowledges the device
+- Starts the processing command asynchronously
+
+If there is a command:
+
+```json
+{
+  "op": "complete-upload",
+  "id": "transaction unique ID",
+  "data": {},
+  "code": 202,
+  "message": "Process queued"
+}
+```
+
+```json
+{
+  "op": "complete-upload",
+  "id": "transaction unique ID",
+  "data": {},
+  "code": 201,
+  "message": "Process started"
+}
+```
+
+When processing completes (or when no processing was required):
+
+```json
+{
+  "op": "complete-upload",
+  "id": "transaction unique ID",
+  "data": {},
+  "code": 200,
+  "message": "Process completed"
+}
+```
+
+Appropriate error messages are sent when:
+
+- No prepared upload exists for this `id`
+- Invalid command
+- Validation fails or an OCI service call fails
+
+### Janitor
+
+A separate janitor tool lists and optionally prunes leftover PARs, for example
+when a device never completes an upload.
+
+## OCI IoT Platform Resources
+
+The [file_agent](./DTDL/file_agent_model.json) model describes the `commandDetails`
+object expected by the file agent.
+
+To enable the file upload capability, a digital twin model must include this
+model as a component, for example:
+
+```json
+    {
+      "@type": "Component",
+      "name": "file",
+      "schema": "dtmi:com:oracle:iot:fileagent;1",
+      "displayName": "File Upload Component"
+    }
+```
+
+A device adapter route must map the device payload to that component, for
+example:
+
+```json
+    "payloadMapping": {
+      "$.file.commandDetails": "${ {\"op\": .op, \"id\": .id, \"data\": .data } }"
+    }
+```
+
+In the OCI IoT Platform, the _Content Path_ for normalized and historized data is
+the component name from the device model (`file`) joined with the object name from the
+file agent model (`commandDetails`). In this sample, that content path is
+`file.commandDetails`.
+
+This project provides a sample [_uploader_](./DTDL/uploader_model.json) model
+and adapter ([envelope](./DTDL/uploader_adapter_envelope.json),
+[routes](./DTDL/uploader_adapter_routes.json)) for demonstration purposes.
+
+Create the IoT resources:
+
+```shell
+# Create the file agent model
+oci iot digital-twin-model create \
+  --display-name "file-agent-interface" \
+  --description "File Agent interface" \
+  --iot-domain-id "ocid1.iotdomain.oc1.<region>..." \
+  --spec file://DTDL/file_agent_model.json
+
+# Create the demo model and adapter
+oci iot digital-twin-model create \
+  --display-name "file-uploader" \
+  --description "File uploader demo" \
+  --iot-domain-id "ocid1.iotdomain.oc1.<region>..." \
+  --spec file://DTDL/uploader_model.json
+
+oci iot digital-twin-adapter create \
+  --display-name "file-uploader" \
+  --description "File uploader demo" \
+  --iot-domain-id "ocid1.iotdomain.oc1.<region>..." \
+  --digital-twin-model-spec-uri "dtmi:com:oracle:iot:uploader;1" \
+  --inbound-envelope file://DTDL/uploader_adapter_envelope.json \
+  --inbound-routes file://DTDL/uploader_adapter_routes.json
+
+# Create the Digital Twin Instance.
+# For simplicity, this example uses secret-based authentication.
+oci iot digital-twin-instance create \
+  --display-name "uploader-01" \
+  --description "File Uploader 01" \
+  --iot-domain-id "ocid1.iotdomain.oc1.<region>..." \
+  --digital-twin-adapter-id "ocid1.iotdigitaltwinadapter.oc1.<region>..." \
+  --external-key "uploader-01" \
+  --auth-id "ocid1.vaultsecret.oc1.<region>..."
+```
+
+## File Agent
+
+### Installation
+
+Use Python 3.12 or higher. From the repository root, create and activate a
+virtual environment, then install the file agent package:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ./file-agent
+file-agent --help
+```
+
+To install the optional test dependencies and run the test suite:
+
+```shell
+python -m pip install -e './file-agent[test]'
+python -m pytest -v file-agent/tests
+```
+
+### Configuration
+
+Use [`file-agent-config.yaml`](./file-agent-config.yaml) as a template and
+update it for the target OCI IoT domain and Object Storage bucket.
+
+- `oci`: OCI authentication settings. Supported values are
+  `ConfigFileAuthentication`, `InstancePrincipal`, and `SecurityToken`.
+- `iot`: IoT domain OCID, queue subscriber, content path, and raw-command
+  response endpoint settings. The domain short ID, database connect string, and
+  database token scope are derived from the IoT domain and its parent domain
+  group at startup.
+- `object_storage`: upload bucket, optional namespace, maximum PAR TTL, and PAR
+  name prefix.
+- `commands`: optional command aliases mapped to absolute executable paths.
+- `oracledb`: optional local Oracle Database driver settings, such as Thick mode.
+
+The file agent typically runs on an OCI Compute Instance and authenticates using
+Instance Principal. See the
+[Connecting Directly to the IoT Database](https://docs.oracle.com/en-us/iaas/Content/internet-of-things/connect-database.htm)
+scenario for more details.
+
+### Running
+
+Create the normalized-data queue subscriber:
+
+```shell
+file-agent --config-file file-agent-config.yaml subscribe
+```
+
+Run the monitor:
+
+```shell
+file-agent --config-file file-agent-config.yaml monitor
+```
+
+Remove the subscriber:
+
+```shell
+file-agent --config-file file-agent-config.yaml unsubscribe
+```
+
+List and prune leftover PARs:
+
+```shell
+file-agent --config-file file-agent-config.yaml janitor list
+file-agent --config-file file-agent-config.yaml janitor prune \
+  --min-age-minutes 60
+```
+
+## Device Demo
+
+The `file-agent-device-demo` command simulates a device over MQTT. It connects
+to the IoT MQTT device-data endpoint using TLS on port `8883`, with MQTT
+`clean_session` disabled so the client uses a persistent session.
+
+```shell
+file-agent-device-demo \
+  '<IoT device host>' \
+  'mqtt-username' \
+  'mqtt-password'
+```
+
+The demo publishes `prepare-upload`, uploads a generated test file to the
+returned `upload_url`, then publishes `complete-upload` with the uploaded file
+name in `data.parameters.artifacts`. It prints each MQTT, upload, and response
+step at INFO level. By default it uses `iot/v1/file/cmd` for device commands,
+`iot/v1/file/rsp` for responses, and the `demo` post-processing command alias.

--- a/samples/python/file-agent/commands/demo.sh
+++ b/samples/python/file-agent/commands/demo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Demo command for the file agent.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+PGM=${0##*/}
+readonly PGM
+
+# Get arguments
+if [[ $# -ne 1 ]]; then
+  echo "Usage: ${PGM} message_in_json_format" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "${PGM}: jq is required" >&2
+  exit 127
+fi
+
+message="$1"
+if ! jq -e . >/dev/null 2>&1 <<<"${message}"; then
+  echo "${PGM}: invalid message JSON" >&2
+  exit 1
+fi
+
+message_id=$(jq -r .message_id <<<"${message}")
+instance_id=$(jq -r .digital_twin_instance_id <<<"${message}")
+display_name=$(jq -r .digital_twin_display_name <<<"${message}")
+time_observed=$(jq -r .time_observed <<<"${message}")
+content_path=$(jq -r .content_path <<<"${message}")
+request=$(jq .request <<<"${message}")
+
+echo "${PGM}: === Message metadata ==="
+echo "${PGM}: Message ID   : ${message_id}"
+echo "${PGM}: Instance ID  : ${instance_id}"
+echo "${PGM}: Display name : ${display_name}"
+echo "${PGM}: Time observed: ${time_observed}"
+echo "${PGM}: Content path : ${content_path}"
+
+request_id=$(jq -r .id <<<"${request}")
+data=$(jq .data <<<"${request}")
+echo
+echo "${PGM}: === Message request ==="
+echo "${PGM}: Request Id: ${request_id}"
+echo "${PGM}: Data:"
+jq <<<"${data}"
+
+if jq -e 'if (.parameters | type) == "object" then (.parameters | has("sleep")) else false end' <<<"${data}" >/dev/null; then
+  sleep=$(jq -er '.parameters.sleep | select(type == "number" and . >= 0)' <<<"${data}") || {
+    echo "${PGM}: parameters.sleep must be a non-negative number" >&2
+    exit 1
+  }
+  echo "${PGM}: sleeping for ${sleep} seconds"
+  sleep "${sleep}"
+fi
+
+echo "${PGM}: Done"

--- a/samples/python/file-agent/file-agent-config.yaml
+++ b/samples/python/file-agent/file-agent-config.yaml
@@ -1,0 +1,39 @@
+#
+# file-agent configuration template.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# cspell:disable
+oci:
+  auth_type: InstancePrincipal
+  # profile: null
+
+iot:
+  domain_id: "ocid1.iotdomain.oc1.<region>..."
+  subscriber_name: file_agent
+  digital_twin:
+    instance_id: null
+    display_name: null
+  # content_path: file.commandDetails
+  # response_endpoint: iot/v1/file/rsp
+
+object_storage:
+  namespace_name: "Object Storage namespace"
+  bucket_name: "Upload bucket"
+  # max_ttl_minutes: 60
+  # par_name_prefix: file-agent
+
+commands:
+  demo: /absolute/path/scripts/demo.sh
+
+# Optional Oracle Database local driver settings.
+# oracledb:
+#   thick_mode: false
+#   thick_mode_lib_dir: null
+
+# cspell:enable

--- a/samples/python/file-agent/file-agent/file_agent/__init__.py
+++ b/samples/python/file-agent/file-agent/file_agent/__init__.py
@@ -1,0 +1,13 @@
+#
+# OCI IoT Platform file upload agent package.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""OCI IoT Platform file upload agent."""
+
+__version__ = "0.1.0"

--- a/samples/python/file-agent/file-agent/file_agent/cli.py
+++ b/samples/python/file-agent/file-agent/file_agent/cli.py
@@ -1,0 +1,304 @@
+#
+# Command-line interface for the file agent.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""Command-line interface for the file agent."""
+
+import logging
+import os
+import queue
+import threading
+from typing import Optional, TextIO
+
+import click
+from oci import iot as oci_iot
+from oci import object_storage as oci_object_storage
+
+from . import __version__, iot_db, iot_raw, oci_auth
+from . import config as app_config
+from .iot_context import IOTDomainContext, derive_iot_domain_context
+from .object_storage import PARService
+from .processor import STOP_WORKER, MessageProcessor, command_worker
+
+LOGGER_FMT = (
+    "{asctime} - {levelname:8} - {filename:12.12} - {threadName:12.12} - {message}"
+)
+
+
+class CLIContext:
+    """Click context object."""
+
+    def __init__(self):
+        """Initialize the context object."""
+        self.config: Optional[app_config.AppConfig] = None
+        self.connection = None
+
+
+@click.group()
+@click.option("-v", "--verbose", is_flag=True, help="Enable info logging.")
+@click.option("-d", "--debug", is_flag=True, help="Enable debug logging.")
+@click.option(
+    "--config-file",
+    type=click.File(mode="r"),
+    default=app_config.DEFAULT_CONFIG_FILE,
+    help="Path to the file-agent YAML configuration.",
+    show_default=True,
+)
+@click.version_option(version=__version__)
+@click.pass_context
+def cli(
+    ctx: click.Context,
+    verbose: bool,
+    debug: bool,
+    config_file: TextIO,
+) -> None:
+    """Manage OCI IoT file upload transactions."""
+    ctx.ensure_object(CLIContext)
+    logging.basicConfig(level=_log_level(verbose, debug), format=LOGGER_FMT, style="{")
+    if debug:
+        _quiet_oci_loggers()
+    try:
+        ctx.obj.config = app_config.load_config(config_file)
+    except Exception as exc:
+        raise click.UsageError(f"Invalid configuration: {exc}") from exc
+
+
+@cli.command()
+@click.pass_context
+def subscribe(ctx: click.Context) -> None:
+    """Register the normalized-data queue subscriber."""
+    config = _require_config(ctx)
+    iot_client = create_iot_client(config)
+    domain_context = derive_iot_domain_context(iot_client, config.iot.domain_id)
+    connection = _connect_database(config, domain_context)
+    try:
+        rule = iot_db.build_subscriber_rule(
+            connection=connection,
+            iot_domain_short_id=domain_context.domain_short_id,
+            digital_twin_instance_id=config.iot.digital_twin.instance_id,
+            display_name=config.iot.digital_twin.display_name,
+            content_path=config.iot.content_path,
+        )
+        iot_db.add_subscriber(
+            connection=connection,
+            queue_name=queue_name(domain_context),
+            subscriber_name=config.iot.subscriber_name,
+            rule=rule,
+        )
+    finally:
+        iot_db.db_disconnect(connection)
+
+    click.echo(f"Subscriber {config.iot.subscriber_name} registered")
+
+
+@cli.command()
+@click.pass_context
+def unsubscribe(ctx: click.Context) -> None:
+    """Remove the normalized-data queue subscriber."""
+    config = _require_config(ctx)
+    iot_client = create_iot_client(config)
+    domain_context = derive_iot_domain_context(iot_client, config.iot.domain_id)
+    connection = _connect_database(config, domain_context)
+    try:
+        iot_db.remove_subscriber(
+            connection=connection,
+            queue_name=queue_name(domain_context),
+            subscriber_name=config.iot.subscriber_name,
+        )
+    finally:
+        iot_db.db_disconnect(connection)
+
+    click.echo(f"Subscriber {config.iot.subscriber_name} removed")
+
+
+@cli.command()
+@click.pass_context
+def monitor(ctx: click.Context) -> None:
+    """Monitor file upload requests."""
+    config = _require_config(ctx)
+    iot_client, object_storage_client = create_oci_clients(config)
+    domain_context = derive_iot_domain_context(iot_client, config.iot.domain_id)
+    par_service = create_par_service(config, object_storage_client)
+    connection = _connect_database(config, domain_context)
+    work_queue: queue.Queue = queue.Queue()
+
+    def responder(message, response):
+        iot_raw.send_response(
+            iot_client=iot_client,
+            digital_twin_instance_id=message.digital_twin_instance_id,
+            endpoint=config.iot.response_endpoint,
+            response=response,
+        )
+
+    def invalid_message_handler(digital_twin_instance_id, _error):
+        iot_raw.send_payload(
+            iot_client=iot_client,
+            digital_twin_instance_id=digital_twin_instance_id,
+            endpoint=config.iot.response_endpoint,
+            payload={"code": 400, "message": "Bad request"},
+        )
+
+    processor = MessageProcessor(
+        par_service=par_service,
+        commands=config.commands,
+        responder=responder,
+    )
+    worker = threading.Thread(
+        target=command_worker,
+        name="CmdWorker",
+        kwargs={"work_queue": work_queue, "processor": processor},
+    )
+    worker.start()
+
+    class ProcessingQueue:
+        def put(self, message):
+            processor.handle_message(message, command_queue=work_queue)
+
+    try:
+        iot_db.dequeue_messages(
+            connection=connection,
+            queue_name=queue_name(domain_context),
+            subscriber_name=config.iot.subscriber_name,
+            iot_domain_short_id=domain_context.domain_short_id,
+            message_queue=ProcessingQueue(),
+            invalid_message_handler=invalid_message_handler,
+        )
+    except KeyboardInterrupt:
+        click.echo("\nInterrupted")
+    finally:
+        work_queue.put(STOP_WORKER)
+        work_queue.join()
+        worker.join()
+        iot_db.db_disconnect(connection)
+
+
+@cli.group()
+def janitor() -> None:
+    """Inspect and prune stale upload PARs."""
+
+
+@janitor.command(name="list")
+@click.pass_context
+def janitor_list(ctx: click.Context) -> None:
+    """List active file-agent PARs."""
+    service = create_par_service(_require_config(ctx))
+    for par in service.list_file_agent_pars():
+        click.echo(
+            "\t".join(
+                [
+                    getattr(par, "id", ""),
+                    getattr(par, "name", ""),
+                    getattr(par, "object_name", ""),
+                    str(getattr(par, "time_created", "")),
+                ]
+            )
+        )
+
+
+@janitor.command(name="prune")
+@click.option(
+    "--min-age-minutes",
+    type=click.IntRange(min=0),
+    default=0,
+    show_default=True,
+    help="Only prune PARs at least this many minutes old.",
+)
+@click.pass_context
+def janitor_prune(ctx: click.Context, min_age_minutes: int) -> None:
+    """Delete stale file-agent PARs."""
+    service = create_par_service(_require_config(ctx))
+    deleted = service.prune(min_age_minutes=min_age_minutes)
+    click.echo(f"Deleted {len(deleted)} PAR(s)")
+
+
+def queue_name(domain_context: IOTDomainContext) -> str:
+    """Return the normalized-data queue name for the IoT domain."""
+    return f"{domain_context.domain_short_id}__iot.normalized_data".upper()
+
+
+def create_oci_clients(
+    config: app_config.AppConfig,
+) -> tuple[oci_iot.IotClient, oci_object_storage.ObjectStorageClient]:
+    """Create OCI IoT and Object Storage clients."""
+    return create_iot_client(config), create_object_storage_client(config)
+
+
+def create_iot_client(config: app_config.AppConfig) -> oci_iot.IotClient:
+    """Create an OCI IoT client."""
+    oci_config, signer = _oci_config_and_signer(config)
+    return oci_iot.IotClient(config=oci_config, **signer)
+
+
+def create_object_storage_client(
+    config: app_config.AppConfig,
+) -> oci_object_storage.ObjectStorageClient:
+    """Create an OCI Object Storage client."""
+    oci_config, signer = _oci_config_and_signer(config)
+    return oci_object_storage.ObjectStorageClient(config=oci_config, **signer)
+
+
+def _oci_config_and_signer(config: app_config.AppConfig) -> tuple[dict, dict]:
+    """Return OCI config and signer kwargs for configured auth."""
+    profile = config.oci.profile or os.getenv("OCI_CLI_PROFILE", "DEFAULT")
+    return oci_auth.get_oci_config(profile, config.oci.auth_type)
+
+
+def create_par_service(
+    config: app_config.AppConfig,
+    object_storage_client: Optional[oci_object_storage.ObjectStorageClient] = None,
+) -> PARService:
+    """Create a PAR service from app configuration."""
+    if object_storage_client is None:
+        object_storage_client = create_object_storage_client(config)
+    return PARService(
+        object_storage_client=object_storage_client,
+        namespace_name=config.object_storage.namespace_name,
+        bucket_name=config.object_storage.bucket_name,
+        max_ttl_minutes=config.object_storage.max_ttl_minutes,
+        par_name_prefix=config.object_storage.par_name_prefix,
+    )
+
+
+def _connect_database(
+    config: app_config.AppConfig,
+    domain_context: IOTDomainContext,
+):
+    return iot_db.db_connect(
+        db_connect_string=domain_context.db_connection_string,
+        db_token_scope=domain_context.db_token_scope,
+        thick_mode=config.oracledb.thick_mode,
+        lib_dir=config.oracledb.thick_mode_lib_dir,
+        oci_auth_type=config.oci.auth_type,
+        oci_profile=config.oci.profile,
+    )
+
+
+def _require_config(ctx: click.Context) -> app_config.AppConfig:
+    config = ctx.obj.config
+    if config is None:
+        raise click.ClickException("Configuration was not loaded")
+    return config
+
+
+def _log_level(verbose: bool, debug: bool) -> int:
+    if debug:
+        return logging.DEBUG
+    if verbose:
+        return logging.INFO
+    return logging.WARNING
+
+
+def _quiet_oci_loggers() -> None:
+    for logger_name in [
+        "oci._vendor.urllib3.connectionpool",
+        "oci.circuit_breaker",
+        "oci.config",
+        "oci.util",
+    ]:
+        logging.getLogger(logger_name).setLevel(logging.INFO)

--- a/samples/python/file-agent/file-agent/file_agent/device_demo.py
+++ b/samples/python/file-agent/file-agent/file_agent/device_demo.py
@@ -1,0 +1,397 @@
+#
+# MQTT device demo for file-agent.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""MQTT device demo for file-agent upload transactions."""
+
+import argparse
+import json
+import logging
+import queue
+import ssl
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+from urllib import request
+from urllib.parse import quote, urlsplit, urlunsplit
+
+MQTT_PORT = 8883
+DEFAULT_COMMAND_TOPIC = "iot/v1/file/cmd"
+DEFAULT_RESPONSE_TOPIC = "iot/v1/file/rsp"
+DEFAULT_KEEPALIVE_SECONDS = 60
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DeviceDemoConfig:
+    """Runtime settings for the device demo."""
+
+    endpoint: str
+    username: str
+    password: str
+    client_id: str
+    command_topic: str
+    response_topic: str
+    transaction_id: str
+    ttl_minutes: int
+    command: str
+    file_path: Optional[Path]
+    timeout_seconds: float
+
+
+def prepare_upload_payload(transaction_id: str, ttl_minutes: int) -> dict[str, Any]:
+    """Return the prepare-upload message payload."""
+    return {
+        "op": "prepare-upload",
+        "id": transaction_id,
+        "data": {"ttl": ttl_minutes},
+    }
+
+
+def complete_upload_payload(
+    transaction_id: str,
+    command: str,
+    file_name: str,
+) -> dict[str, Any]:
+    """Return the complete-upload message payload for the uploaded file."""
+    return {
+        "op": "complete-upload",
+        "id": transaction_id,
+        "data": {
+            "command": command,
+            "parameters": {
+                "artifacts": [file_name],
+            },
+        },
+    }
+
+
+def object_upload_url(upload_url: str, file_name: str) -> str:
+    """Return the object URL for the file within the prepared upload directory."""
+    parts = urlsplit(upload_url)
+    path = parts.path
+    if not path.endswith("/"):
+        path = f"{path}/"
+    path = f"{path}{quote(file_name)}"
+    return urlunsplit(parts._replace(path=path))
+
+
+def mqtt_host(endpoint: str) -> str:
+    """Return the hostname from a bare host or MQTT endpoint URL."""
+    parsed = urlsplit(endpoint if "://" in endpoint else f"//{endpoint}")
+    return parsed.hostname or endpoint
+
+
+def upload_file(
+    upload_url: str,
+    file_path: Path,
+    timeout_seconds: float,
+    opener: Callable[..., Any] = request.urlopen,
+) -> str:
+    """Upload a local file to the prepared Object Storage URL."""
+    object_url = object_upload_url(upload_url, file_path.name)
+    body = file_path.read_bytes()
+    upload_request = request.Request(
+        object_url,
+        data=body,
+        headers={"Content-Type": "application/octet-stream"},
+        method="PUT",
+    )
+    logger.info("Uploading %s bytes to %s", len(body), object_url)
+    with opener(upload_request, timeout=timeout_seconds) as response:
+        status = response.getcode()
+    if status < 200 or status >= 300:
+        raise RuntimeError(f"Upload failed with HTTP status {status}")
+    logger.info("Upload completed with HTTP status %s", status)
+    return object_url
+
+
+def create_default_test_file(directory: Path) -> Path:
+    """Create and return a small test file for the demo upload."""
+    file_path = directory / "file-agent-device-demo.txt"
+    file_path.write_text(
+        "file-agent device demo upload\n",
+        encoding="utf-8",
+    )
+    return file_path
+
+
+def configure_mqtt_client(
+    client_id: str,
+    username: str,
+    password: str,
+    mqtt_module=None,
+):
+    """Create a TLS MQTT client using a persistent MQTT session."""
+    if mqtt_module is None:
+        from paho.mqtt import client as mqtt_module
+
+    client = mqtt_module.Client(
+        callback_api_version=mqtt_module.CallbackAPIVersion.VERSION2,
+        client_id=client_id,
+        clean_session=False,
+        protocol=mqtt_module.MQTTv311,
+    )
+    client.username_pw_set(username, password)
+    client.tls_set_context(ssl.create_default_context())
+    return client
+
+
+def run_demo(config: DeviceDemoConfig) -> int:
+    """Run the device-side upload demo."""
+    connected = threading.Event()
+    subscribed = threading.Event()
+    responses: queue.Queue[dict[str, Any]] = queue.Queue()
+
+    client = configure_mqtt_client(
+        client_id=config.client_id,
+        username=config.username,
+        password=config.password,
+    )
+
+    def on_connect(client, userdata, flags, reason_code, properties):
+        logger.info("Connected to MQTT endpoint: reason_code=%s", reason_code)
+        connected.set()
+
+    def on_disconnect(client, userdata, flags, reason_code, properties):
+        logger.info("Disconnected from MQTT endpoint: reason_code=%s", reason_code)
+
+    def on_subscribe(client, userdata, mid, reason_codes, properties):
+        logger.info("Subscribed to %s", config.response_topic)
+        subscribed.set()
+
+    def on_message(client, userdata, message):
+        payload = message.payload.decode("utf-8")
+        logger.info("Received on %s: %s", message.topic, payload)
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError:
+            logger.error("Ignoring non-JSON response payload")
+            return
+        responses.put(decoded)
+
+    client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
+    client.on_subscribe = on_subscribe
+    client.on_message = on_message
+
+    temporary_directory = None
+    try:
+        file_path = config.file_path
+        if file_path is None:
+            temporary_directory = tempfile.TemporaryDirectory()
+            file_path = create_default_test_file(Path(temporary_directory.name))
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Upload file not found: {file_path}")
+        logger.info("Using upload file %s", file_path)
+
+        host = mqtt_host(config.endpoint)
+        logger.info("Connecting to %s:%s with TLS", host, MQTT_PORT)
+        client.connect(
+            host,
+            MQTT_PORT,
+            keepalive=DEFAULT_KEEPALIVE_SECONDS,
+        )
+        client.loop_start()
+        if not connected.wait(config.timeout_seconds):
+            raise TimeoutError("Timed out waiting for MQTT connection")
+
+        logger.info("Subscribing to response topic %s", config.response_topic)
+        client.subscribe(config.response_topic, qos=1)
+        if not subscribed.wait(config.timeout_seconds):
+            raise TimeoutError("Timed out waiting for response topic subscription")
+
+        prepare_payload = prepare_upload_payload(
+            config.transaction_id,
+            config.ttl_minutes,
+        )
+        publish_json(client, config.command_topic, prepare_payload)
+        prepare_response = wait_for_response(
+            responses,
+            transaction_id=config.transaction_id,
+            operation="prepare-upload",
+            timeout_seconds=config.timeout_seconds,
+        )
+        require_response_code(prepare_response, expected_code=200)
+
+        upload_url = prepare_response.get("data", {}).get("upload_url")
+        if not upload_url:
+            raise RuntimeError("prepare-upload response did not include upload_url")
+
+        upload_file(upload_url, file_path, config.timeout_seconds)
+
+        complete_payload = complete_upload_payload(
+            transaction_id=config.transaction_id,
+            command=config.command,
+            file_name=file_path.name,
+        )
+        publish_json(client, config.command_topic, complete_payload)
+        complete_response = wait_for_terminal_response(
+            responses,
+            transaction_id=config.transaction_id,
+            operation="complete-upload",
+            timeout_seconds=config.timeout_seconds,
+        )
+        require_response_code(complete_response, expected_code=200)
+    finally:
+        logger.info("Disconnecting from MQTT endpoint")
+        client.disconnect()
+        client.loop_stop()
+        if temporary_directory is not None:
+            temporary_directory.cleanup()
+
+    logger.info("Device demo completed")
+    return 0
+
+
+def publish_json(client, topic: str, payload: dict[str, Any]) -> None:
+    """Publish a JSON MQTT message and wait for it to leave the client."""
+    encoded = json.dumps(payload, separators=(",", ":"))
+    logger.info("Publishing to %s: %s", topic, json.dumps(payload, indent=2))
+    publish_info = client.publish(topic, encoded, qos=1)
+    publish_info.wait_for_publish()
+
+
+def wait_for_response(
+    responses: queue.Queue[dict[str, Any]],
+    transaction_id: str,
+    operation: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Wait for the next response matching an operation and transaction."""
+    end_time = time.monotonic() + timeout_seconds
+    while True:
+        remaining = end_time - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"Timed out waiting for {operation} response")
+        response = responses.get(timeout=remaining)
+        if response.get("id") == transaction_id and response.get("op") == operation:
+            return response
+        logger.info("Ignoring response for different transaction or operation")
+
+
+def wait_for_terminal_response(
+    responses: queue.Queue[dict[str, Any]],
+    transaction_id: str,
+    operation: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Wait for a terminal response code for an operation and transaction."""
+    end_time = time.monotonic() + timeout_seconds
+    while True:
+        response = wait_for_response(
+            responses,
+            transaction_id,
+            operation,
+            max(0.1, end_time - time.monotonic()),
+        )
+        code = response.get("code")
+        if code in {200, 400, 422, 500}:
+            return response
+        logger.info("Received non-terminal response code %s", code)
+
+
+def require_response_code(response: dict[str, Any], expected_code: int) -> None:
+    """Raise if a file-agent response did not return the expected code."""
+    code = response.get("code")
+    if code != expected_code:
+        raise RuntimeError(
+            f"Unexpected response code {code}: {response.get('message', '')}"
+        )
+    logger.info("Response accepted: code=%s message=%s", code, response.get("message"))
+
+
+def parse_args(argv: Optional[list[str]] = None) -> DeviceDemoConfig:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("endpoint", help="IoT MQTT device data endpoint hostname.")
+    parser.add_argument("username", help="MQTT username.")
+    parser.add_argument("password", help="MQTT password.")
+    parser.add_argument(
+        "--client-id",
+        help="MQTT client identifier. Defaults to the username.",
+    )
+    parser.add_argument(
+        "--command-topic",
+        default=DEFAULT_COMMAND_TOPIC,
+        help=f"MQTT command topic. Default: {DEFAULT_COMMAND_TOPIC}",
+    )
+    parser.add_argument(
+        "--response-topic",
+        default=DEFAULT_RESPONSE_TOPIC,
+        help=f"MQTT response topic. Default: {DEFAULT_RESPONSE_TOPIC}",
+    )
+    parser.add_argument(
+        "--transaction-id",
+        default=f"demo-{uuid.uuid4().hex}",
+        help="Upload transaction id.",
+    )
+    parser.add_argument(
+        "--ttl",
+        type=int,
+        default=10,
+        dest="ttl_minutes",
+        help="Requested upload URL TTL in minutes.",
+    )
+    parser.add_argument(
+        "--command",
+        default="demo",
+        help="file-agent command alias to request after upload.",
+    )
+    parser.add_argument(
+        "--file",
+        type=Path,
+        dest="file_path",
+        help="Local file to upload. Defaults to a generated test file.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        dest="timeout_seconds",
+        help="Timeout in seconds for MQTT responses and HTTP upload.",
+    )
+    args = parser.parse_args(argv)
+
+    return DeviceDemoConfig(
+        endpoint=args.endpoint,
+        username=args.username,
+        password=args.password,
+        client_id=args.client_id if args.client_id is not None else args.username,
+        command_topic=args.command_topic,
+        response_topic=args.response_topic,
+        transaction_id=args.transaction_id,
+        ttl_minutes=args.ttl_minutes,
+        command=args.command,
+        file_path=args.file_path,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Run the device demo command-line interface."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+    try:
+        return run_demo(parse_args(argv))
+    except Exception:
+        logger.exception("Device demo failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/samples/python/file-agent/file-agent/file_agent/iot_context.py
+++ b/samples/python/file-agent/file-agent/file_agent/iot_context.py
@@ -1,0 +1,53 @@
+#
+# OCI IoT domain context derivation.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""OCI IoT domain context derivation."""
+
+from dataclasses import dataclass
+
+from oci import iot as oci_iot
+
+
+@dataclass(frozen=True)
+class IOTDomainContext:
+    """Derived IoT domain settings used by DB/AQ access."""
+
+    domain_short_id: str
+    db_connection_string: str
+    db_token_scope: str
+
+
+def derive_iot_domain_context(
+    iot_client: oci_iot.IotClient,
+    iot_domain_id: str,
+) -> IOTDomainContext:
+    """Derive DB/AQ settings from an IoT domain OCID."""
+    domain = iot_client.get_iot_domain(iot_domain_id=iot_domain_id).data
+    device_host = _required_attr(domain, "device_host")
+    domain_group_id = _required_attr(domain, "iot_domain_group_id")
+
+    domain_group = iot_client.get_iot_domain_group(
+        iot_domain_group_id=domain_group_id
+    ).data
+    db_connection_string = _required_attr(domain_group, "db_connection_string")
+    db_token_scope = _required_attr(domain_group, "db_token_scope")
+
+    return IOTDomainContext(
+        domain_short_id=device_host.split(".", maxsplit=1)[0],
+        db_connection_string=db_connection_string,
+        db_token_scope=db_token_scope,
+    )
+
+
+def _required_attr(resource, attr_name: str) -> str:
+    value = getattr(resource, attr_name, None)
+    if not value:
+        raise ValueError(f"Missing {attr_name} in OCI IoT response")
+    return value

--- a/samples/python/file-agent/file-agent/file_agent/iot_db.py
+++ b/samples/python/file-agent/file-agent/file_agent/iot_db.py
@@ -1,0 +1,243 @@
+#
+# Oracle DB/AQ access for OCI IoT normalized data.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""Oracle DB/AQ access for OCI IoT normalized data."""
+
+import logging
+import queue
+import re
+from collections.abc import Callable
+from typing import Any, Optional
+
+import oracledb
+import oracledb.plugins.oci_tokens
+from pydantic import ValidationError
+
+from .models import InboundMessage
+
+logger = logging.getLogger(__name__)
+
+InvalidMessageHandler = Callable[[str, ValidationError], None]
+
+
+def db_connect(
+    db_connect_string: str,
+    db_token_scope: str,
+    thick_mode: bool = False,
+    lib_dir: Optional[str] = None,
+    oci_auth_type: str = "ConfigFileAuthentication",
+    oci_profile: Optional[str] = "DEFAULT",
+) -> oracledb.Connection:
+    """Connect to the IoT Platform database using OCI token authentication."""
+    match = re.match(r"tcps:(.*):(\d+)/([^?]*)(\?.*)?", db_connect_string)
+    if not match:
+        raise ValueError("Invalid connect string")
+    hostname, port, service, _ = match.groups()
+    dsn = f"""
+        (DESCRIPTION =
+            (ADDRESS=(PROTOCOL=TCPS)(PORT={port})(HOST={hostname}))
+            (CONNECT_DATA=(SERVICE_NAME={service}))
+        )"""
+
+    token_based_auth = {
+        "auth_type": oci_auth_type,
+        "scope": db_token_scope,
+    }
+    if oci_auth_type in ["ConfigFileAuthentication", "SecurityToken"]:
+        token_based_auth["profile"] = oci_profile or "DEFAULT"
+
+    connect_kwargs = {}
+    if thick_mode:
+        oracledb.init_oracle_client(lib_dir=lib_dir, config_dir=".")
+        connect_kwargs["externalauth"] = True
+
+    return oracledb.connect(
+        dsn=dsn,
+        extra_auth_params=token_based_auth,
+        **connect_kwargs,
+    )
+
+
+def db_disconnect(connection: oracledb.Connection) -> None:
+    """Close a database connection."""
+    connection.close()
+
+
+def build_subscriber_rule(
+    connection: oracledb.Connection,
+    iot_domain_short_id: str,
+    digital_twin_instance_id: Optional[str],
+    display_name: Optional[str],
+    content_path: Optional[str],
+) -> Optional[str]:
+    """Build a normalized-data subscriber rule."""
+    rule = None
+    with connection.cursor() as cursor:
+        if display_name:
+            cursor.execute(
+                f"""
+                    select dti.data.id
+                    from {iot_domain_short_id}__iot.digital_twin_instances dti
+                    where dti.data."displayName" = :display_name
+                    and dti.data."lifecycleState" = 'ACTIVE'
+                    order by dti.data."timeUpdated" desc
+                """,
+                {"display_name": display_name},
+            )
+            row = cursor.fetchone()
+            if row and row[0]:
+                digital_twin_instance_id = row[0]
+            else:
+                raise ValueError(f"No such display name: {display_name}")
+
+        if digital_twin_instance_id:
+            quoted_instance_id = cursor.callfunc(
+                "dbms_assert.enquote_literal",
+                str,
+                [digital_twin_instance_id],
+            )
+            condition = f'tab.user_data."digitalTwinInstanceId" = {quoted_instance_id}'
+            rule = f"{rule} and {condition}" if rule is not None else condition
+
+        if content_path:
+            quoted_content_path = cursor.callfunc(
+                "dbms_assert.enquote_literal",
+                str,
+                [content_path],
+            )
+            condition = f'tab.user_data."contentPath" = {quoted_content_path}'
+            rule = f"{rule} and {condition}" if rule is not None else condition
+
+    logger.debug("Queue rule is: %s", rule)
+    return rule
+
+
+def add_subscriber(
+    connection: oracledb.Connection,
+    queue_name: str,
+    subscriber_name: str,
+    rule: Optional[str],
+) -> None:
+    """Register a normalized-data queue subscriber."""
+    agent_type = connection.gettype("SYS.AQ$_AGENT")
+    subscriber = agent_type.newobject()
+    subscriber.NAME = subscriber_name
+    subscriber.ADDRESS = None
+    subscriber.PROTOCOL = 0
+    with connection.cursor() as cursor:
+        cursor.callproc(
+            "dbms_aqadm.add_subscriber",
+            keyword_parameters={
+                "queue_name": queue_name,
+                "subscriber": subscriber,
+                "rule": rule,
+                "transformation": None,
+                "queue_to_queue": False,
+                "delivery_mode": oracledb.MSG_PERSISTENT_OR_BUFFERED,
+            },
+        )
+
+
+def remove_subscriber(
+    connection: oracledb.Connection,
+    queue_name: str,
+    subscriber_name: str,
+) -> None:
+    """Remove a normalized-data queue subscriber."""
+    agent_type = connection.gettype("SYS.AQ$_AGENT")
+    subscriber = agent_type.newobject()
+    subscriber.NAME = subscriber_name
+    subscriber.ADDRESS = None
+    subscriber.PROTOCOL = 0
+    with connection.cursor() as cursor:
+        cursor.callproc(
+            "dbms_aqadm.remove_subscriber",
+            keyword_parameters={
+                "queue_name": queue_name,
+                "subscriber": subscriber,
+            },
+        )
+
+
+def dequeue_messages(
+    connection: oracledb.Connection,
+    queue_name: str,
+    subscriber_name: str,
+    iot_domain_short_id: str,
+    message_queue: queue.Queue,
+    invalid_message_handler: Optional[InvalidMessageHandler] = None,
+    max_messages: Optional[int] = None,
+) -> None:
+    """Dequeue normalized IoT messages and forward valid file-agent requests."""
+    db_queue = connection.queue(name=queue_name, payload_type="JSON")
+    db_queue.deqOptions.mode = oracledb.DEQ_REMOVE
+    db_queue.deqOptions.wait = 10
+    db_queue.deqOptions.navigation = oracledb.DEQ_FIRST_MSG
+    db_queue.deqOptions.consumername = subscriber_name
+
+    processed = 0
+    while max_messages is None or processed < max_messages:
+        message = db_queue.deqone()
+        if message is None:
+            if max_messages is None:
+                continue
+            break
+
+        processed += 1
+        logger.info("Received message ID: %s", message.msgid.hex())
+        connection.commit()
+        try:
+            inbound_message = InboundMessage.model_validate(message.payload)
+        except ValidationError as exc:
+            logger.error("Invalid message dequeued: %s", exc)
+            instance_id = _payload_instance_id(message.payload)
+            if instance_id and invalid_message_handler:
+                invalid_message_handler(instance_id, exc)
+            continue
+
+        inbound_message.message_id = message.msgid.hex()
+        display_name = resolve_display_name(
+            connection,
+            iot_domain_short_id,
+            inbound_message.digital_twin_instance_id,
+        )
+        if display_name:
+            inbound_message.digital_twin_display_name = display_name
+
+        message_queue.put(inbound_message)
+
+
+def resolve_display_name(
+    connection: oracledb.Connection,
+    iot_domain_short_id: str,
+    digital_twin_instance_id: str,
+) -> Optional[str]:
+    """Resolve a Digital Twin display name for logging and command payloads."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"""
+                select dti.data."displayName"
+                from {iot_domain_short_id}__iot.digital_twin_instances dti
+                where dti.data.id = :instance_id
+            """,
+            {"instance_id": digital_twin_instance_id},
+        )
+        row = cursor.fetchone()
+        if row and row[0]:
+            return row[0]
+    return None
+
+
+def _payload_instance_id(payload: Any) -> Optional[str]:
+    if isinstance(payload, dict):
+        value = payload.get("digitalTwinInstanceId")
+        if isinstance(value, str):
+            return value
+    return None

--- a/samples/python/file-agent/file-agent/file_agent/iot_raw.py
+++ b/samples/python/file-agent/file-agent/file_agent/iot_raw.py
@@ -1,0 +1,77 @@
+#
+# OCI IoT raw-command response publishing.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""OCI IoT raw-command response publishing."""
+
+import logging
+from typing import Any
+
+from oci import exceptions as oci_exceptions
+from oci import iot as oci_iot
+
+from .models import ProtocolResponse
+
+logger = logging.getLogger(__name__)
+
+
+def send_response(
+    iot_client: oci_iot.IotClient,
+    digital_twin_instance_id: str,
+    endpoint: str,
+    response: ProtocolResponse,
+) -> bool:
+    """Send a file-agent protocol response to a Digital Twin instance."""
+    return send_payload(
+        iot_client=iot_client,
+        digital_twin_instance_id=digital_twin_instance_id,
+        endpoint=endpoint,
+        payload=response.to_payload(),
+    )
+
+
+def send_payload(
+    iot_client: oci_iot.IotClient,
+    digital_twin_instance_id: str,
+    endpoint: str,
+    payload: dict[str, Any],
+) -> bool:
+    """Send an arbitrary JSON response payload to a Digital Twin instance."""
+    raw_command = oci_iot.models.InvokeRawJsonCommandDetails(
+        request_duration="PT60M",
+        request_endpoint=endpoint,
+        request_data=payload,
+    )
+    try:
+        result = iot_client.invoke_raw_command(
+            digital_twin_instance_id=digital_twin_instance_id,
+            invoke_raw_command_details=raw_command,
+        )
+    except oci_exceptions.ServiceError as exc:
+        logger.error(
+            "Cannot send response to Digital Twin Instance %s: %s %s",
+            digital_twin_instance_id,
+            exc.status,
+            exc.message,
+        )
+        return False
+
+    if result and result.status == 202:
+        logger.debug(
+            "Response sent to Digital Twin Instance %s", digital_twin_instance_id
+        )
+        return True
+
+    logger.error(
+        "Unexpected raw-command response for %s: %s - %s",
+        digital_twin_instance_id,
+        result.status if result else None,
+        result.data if result else None,
+    )
+    return False

--- a/samples/python/file-agent/file-agent/file_agent/models.py
+++ b/samples/python/file-agent/file-agent/file_agent/models.py
@@ -1,0 +1,101 @@
+#
+# Protocol models for file upload transactions.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""Protocol models for file upload transactions."""
+
+import re
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, field_validator
+
+Operation = Literal["prepare-upload", "complete-upload"]
+TRANSACTION_ID_MAX_LENGTH = 128
+TRANSACTION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def validate_transaction_id(value: str) -> str:
+    """Validate a transaction id before it is used in paths or URLs."""
+    if (
+        not isinstance(value, str)
+        or len(value) < 1
+        or len(value) > TRANSACTION_ID_MAX_LENGTH
+        or not TRANSACTION_ID_PATTERN.fullmatch(value)
+    ):
+        raise ValueError(
+            "Transaction id must be 1-128 characters of A-Z, a-z, 0-9, '.', "
+            "'_', or '-', and must start with a letter or digit"
+        )
+    return value
+
+
+class PARRequestData(BaseModel):
+    """Data payload for a PAR staging request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ttl: PositiveInt = 60
+
+
+class UploadRequestData(BaseModel):
+    """Data payload for an upload completion request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command: Optional[str] = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProtocolRequest(BaseModel):
+    """Device request payload after adapter mapping."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    op: Operation
+    id: str = Field(min_length=1, max_length=TRANSACTION_ID_MAX_LENGTH)
+    data: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("id")
+    @classmethod
+    def check_transaction_id(cls, value: str) -> str:
+        """Reject ids that are unsafe as Object Storage path components."""
+        return validate_transaction_id(value)
+
+
+class ProtocolResponse(BaseModel):
+    """Backend response payload sent to the device."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    op: Operation
+    id: str
+    data: dict[str, Any] = Field(default_factory=dict)
+    code: int
+    message: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the JSON-serializable response payload."""
+        return self.model_dump(mode="json")
+
+
+class InboundMessage(BaseModel):
+    """Normalized queue message carrying a file-agent request."""
+
+    model_config = ConfigDict(
+        extra="ignore",
+        validate_by_alias=True,
+        validate_by_name=False,
+    )
+
+    message_id: str = ""
+    digital_twin_instance_id: str = Field(validation_alias="digitalTwinInstanceId")
+    digital_twin_display_name: str = "unknown"
+    time_observed: str = Field(validation_alias="timeObserved")
+    content_path: str = Field(validation_alias="contentPath")
+    request: ProtocolRequest = Field(validation_alias="value")

--- a/samples/python/file-agent/file-agent/file_agent/object_storage.py
+++ b/samples/python/file-agent/file-agent/file_agent/object_storage.py
@@ -1,0 +1,185 @@
+#
+# Object Storage pre-authenticated request lifecycle helpers.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""Object Storage pre-authenticated request lifecycle helpers."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from oci import object_storage
+from oci.object_storage.models import CreatePreauthenticatedRequestDetails
+
+from .models import validate_transaction_id
+
+
+@dataclass(frozen=True)
+class StageUploadResult:
+    """Result returned after creating an upload PAR."""
+
+    par_id: str
+    upload_url: str
+    object_prefix: str
+    time_expires: datetime
+
+
+class PARService:
+    """Manage file-agent Object Storage PARs."""
+
+    def __init__(
+        self,
+        object_storage_client: object_storage.ObjectStorageClient,
+        bucket_name: str,
+        namespace_name: Optional[str] = None,
+        max_ttl_minutes: int = 60,
+        par_name_prefix: str = "file-agent",
+        now: Callable[[], datetime] | None = None,
+    ):
+        """Initialize the PAR service."""
+        self.object_storage_client = object_storage_client
+        self.namespace_name = namespace_name
+        self.bucket_name = bucket_name
+        self.max_ttl_minutes = max_ttl_minutes
+        self.par_name_prefix = par_name_prefix
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    def stage_upload(
+        self,
+        digital_twin_instance_id: str,
+        transaction_id: str,
+        requested_ttl_minutes: int,
+    ) -> StageUploadResult:
+        """Create a write-only PAR for one device transaction prefix."""
+        ttl_minutes = max(1, min(requested_ttl_minutes, self.max_ttl_minutes))
+        time_expires = self._utc_now() + timedelta(minutes=ttl_minutes)
+        object_prefix = self.object_prefix(digital_twin_instance_id, transaction_id)
+        details = CreatePreauthenticatedRequestDetails(
+            name=self.par_name(digital_twin_instance_id, transaction_id),
+            object_name=object_prefix,
+            access_type=CreatePreauthenticatedRequestDetails.ACCESS_TYPE_ANY_OBJECT_WRITE,
+            time_expires=time_expires,
+        )
+
+        response = self.object_storage_client.create_preauthenticated_request(
+            self._namespace_name(),
+            self.bucket_name,
+            details,
+        )
+
+        return StageUploadResult(
+            par_id=response.data.id,
+            upload_url=self._upload_url(response.data.access_uri, object_prefix),
+            object_prefix=object_prefix,
+            time_expires=time_expires,
+        )
+
+    def complete_upload(
+        self, digital_twin_instance_id: str, transaction_id: str
+    ) -> bool:
+        """Delete the PAR associated with a completed upload transaction."""
+        par = self.find_upload_par(digital_twin_instance_id, transaction_id)
+        if par is None:
+            return False
+
+        self.object_storage_client.delete_preauthenticated_request(
+            self._namespace_name(),
+            self.bucket_name,
+            par.id,
+        )
+        return True
+
+    def find_upload_par(self, digital_twin_instance_id: str, transaction_id: str):
+        """Return the matching file-agent PAR summary, if it exists."""
+        name = self.par_name(digital_twin_instance_id, transaction_id)
+        for par in self.list_file_agent_pars():
+            if par.name == name:
+                return par
+        return None
+
+    def list_file_agent_pars(self):
+        """List Object Storage PARs created by file-agent."""
+        page = None
+        pars = []
+        while True:
+            kwargs = {}
+            if page is not None:
+                kwargs["page"] = page
+            response = self.object_storage_client.list_preauthenticated_requests(
+                self._namespace_name(),
+                self.bucket_name,
+                **kwargs,
+            )
+            pars.extend(
+                par
+                for par in response.data
+                if getattr(par, "name", "").startswith(f"{self.par_name_prefix}:")
+            )
+            page = getattr(response, "next_page", None)
+            if not page:
+                return pars
+
+    def prune(self, min_age_minutes: int = 0) -> list[str]:
+        """Delete file-agent PARs older than the given age threshold."""
+        cutoff = self._utc_now() - timedelta(minutes=min_age_minutes)
+        pruned = []
+        for par in self.list_file_agent_pars():
+            time_created = self._as_utc(getattr(par, "time_created", None))
+            if time_created is None or time_created > cutoff:
+                continue
+            self.object_storage_client.delete_preauthenticated_request(
+                self._namespace_name(),
+                self.bucket_name,
+                par.id,
+            )
+            pruned.append(par.id)
+        return pruned
+
+    def par_name(self, digital_twin_instance_id: str, transaction_id: str) -> str:
+        """Return the deterministic PAR name for a device transaction."""
+        transaction_id = validate_transaction_id(transaction_id)
+        return f"{self.par_name_prefix}:{digital_twin_instance_id}:{transaction_id}"
+
+    @staticmethod
+    def object_prefix(digital_twin_instance_id: str, transaction_id: str) -> str:
+        """Return the Object Storage prefix assigned to a device transaction."""
+        transaction_id = validate_transaction_id(transaction_id)
+        return f"{digital_twin_instance_id}/{transaction_id}/"
+
+    def _namespace_name(self) -> str:
+        if self.namespace_name:
+            return self.namespace_name
+        response = self.object_storage_client.get_namespace()
+        self.namespace_name = response.data
+        return self.namespace_name
+
+    def _full_access_url(self, access_uri: str) -> str:
+        if access_uri.startswith(("http://", "https://")):
+            return access_uri
+        endpoint = self.object_storage_client.base_client.endpoint.rstrip("/")
+        return f"{endpoint}{access_uri}"
+
+    def _upload_url(self, access_uri: str, object_prefix: str) -> str:
+        access_url = self._full_access_url(access_uri)
+        normalized_prefix = object_prefix.strip("/")
+        if access_url.rstrip("/").endswith(normalized_prefix):
+            return f"{access_url.rstrip('/')}/"
+        return f"{access_url.rstrip('/')}/{normalized_prefix}/"
+
+    def _utc_now(self) -> datetime:
+        return self._as_utc(self._now()) or datetime.now(timezone.utc)
+
+    @staticmethod
+    def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)

--- a/samples/python/file-agent/file-agent/file_agent/oci_auth.py
+++ b/samples/python/file-agent/file-agent/file_agent/oci_auth.py
@@ -1,0 +1,43 @@
+#
+# OCI authentication helpers.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""OCI authentication helpers."""
+
+import logging
+
+from oci import config as oci_config
+from oci import signer as oci_signer
+from oci.auth import signers as oci_auth_signers
+
+logger = logging.getLogger(__name__)
+
+
+def get_oci_config(profile: str, auth: str) -> tuple[dict, dict]:
+    """Return OCI SDK config and signer kwargs for the configured auth type."""
+    match auth:
+        case "ConfigFileAuthentication":
+            logger.debug("OCI authentication: config file")
+            return oci_config.from_file(profile_name=profile), {}
+        case "InstancePrincipal":
+            logger.debug("OCI authentication: instance principal")
+            return {}, {
+                "signer": oci_auth_signers.InstancePrincipalsSecurityTokenSigner()
+            }
+        case "SecurityToken":
+            logger.debug("OCI authentication: security token")
+            config = oci_config.from_file(profile_name=profile)
+            with open(config["security_token_file"]) as token_file:
+                token = token_file.read()
+            private_key = oci_signer.load_private_key_from_file(config["key_file"])
+            return config, {
+                "signer": oci_auth_signers.SecurityTokenSigner(token, private_key)
+            }
+        case _:
+            raise ValueError(f"unsupported auth scheme {auth}")

--- a/samples/python/file-agent/file-agent/file_agent/processor.py
+++ b/samples/python/file-agent/file-agent/file_agent/processor.py
@@ -1,0 +1,231 @@
+#
+# Protocol processing and command execution.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+"""Protocol processing and command execution."""
+
+import logging
+import queue
+import subprocess
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Optional, TextIO
+
+from pydantic import ValidationError
+
+from .models import (
+    InboundMessage,
+    PARRequestData,
+    ProtocolResponse,
+    UploadRequestData,
+)
+
+logger = logging.getLogger(__name__)
+
+ResponseSender = Callable[[InboundMessage, ProtocolResponse], None]
+CommandRunner = Callable[[list[str]], Any]
+STOP_WORKER = object()
+
+
+@dataclass(frozen=True)
+class CommandWorkItem:
+    """Queued command execution request."""
+
+    message: InboundMessage
+    upload_data: UploadRequestData
+
+
+class MessageProcessor:
+    """Handle file-agent protocol requests."""
+
+    def __init__(
+        self,
+        par_service,
+        commands: dict[str, str],
+        responder: ResponseSender,
+        command_runner: Optional[CommandRunner] = None,
+    ):
+        """Initialize a message processor."""
+        self.par_service = par_service
+        self.commands = commands
+        self.responder = responder
+        self.command_runner = command_runner or self._default_command_runner
+
+    def handle_message(
+        self,
+        message: InboundMessage,
+        command_queue: Optional[queue.Queue] = None,
+    ) -> None:
+        """Process an inbound protocol message."""
+        match message.request.op:
+            case "prepare-upload":
+                self._handle_prepare_upload(message)
+            case "complete-upload":
+                self._handle_complete_upload(message, command_queue)
+
+    def run_command(
+        self,
+        message: InboundMessage,
+        upload_data: UploadRequestData,
+    ) -> None:
+        """Execute a configured command and send start/completion responses."""
+        command_name = upload_data.command
+        if not command_name or command_name not in self.commands:
+            self._send(message, 422, "Invalid command")
+            return
+
+        self._send(message, 201, "Process started")
+        try:
+            result = self.command_runner(
+                [
+                    self.commands[command_name],
+                    message.model_dump_json(by_alias=True),
+                ]
+            )
+        except Exception:
+            logger.exception("Command failed to start: %s", command_name)
+            self._send(message, 500, "Process failed")
+            return
+
+        if getattr(result, "returncode", 1) == 0:
+            self._send(message, 200, "Process completed")
+        else:
+            self._send(message, 500, "Process failed")
+
+    def _handle_prepare_upload(self, message: InboundMessage) -> None:
+        try:
+            data = PARRequestData.model_validate(message.request.data)
+        except ValidationError:
+            logger.exception("Invalid prepare-upload payload")
+            self._send(message, 400, "Bad request")
+            return
+
+        try:
+            result = self.par_service.stage_upload(
+                digital_twin_instance_id=message.digital_twin_instance_id,
+                transaction_id=message.request.id,
+                requested_ttl_minutes=data.ttl,
+            )
+        except Exception:
+            logger.exception("Upload preparation failed")
+            self._send(message, 500, "Upload preparation failed")
+            return
+
+        self._send(message, 200, "Upload prepared", {"upload_url": result.upload_url})
+
+    def _handle_complete_upload(
+        self,
+        message: InboundMessage,
+        command_queue: Optional[queue.Queue],
+    ) -> None:
+        try:
+            data = UploadRequestData.model_validate(message.request.data)
+        except ValidationError:
+            logger.exception("Invalid complete-upload payload")
+            self._send(message, 400, "Bad request")
+            return
+
+        try:
+            par_deleted = self.par_service.complete_upload(
+                digital_twin_instance_id=message.digital_twin_instance_id,
+                transaction_id=message.request.id,
+            )
+        except Exception:
+            logger.exception("PAR deletion failed")
+            self._send(message, 500, "PAR deletion failed")
+            return
+
+        if not par_deleted:
+            self._send(message, 422, "No prepared upload")
+            return
+
+        if not data.command:
+            self._send(message, 200, "Process completed")
+            return
+
+        if data.command not in self.commands:
+            self._send(message, 422, "Invalid command")
+            return
+
+        self._send(message, 202, "Process queued")
+        work_item = CommandWorkItem(message=message, upload_data=data)
+        if command_queue is None:
+            self.run_command(work_item.message, work_item.upload_data)
+        else:
+            command_queue.put(work_item)
+
+    def _send(
+        self,
+        message: InboundMessage,
+        code: int,
+        response_message: str,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        response = ProtocolResponse(
+            op=message.request.op,
+            id=message.request.id,
+            data=data or {},
+            code=code,
+            message=response_message,
+        )
+        self.responder(message, response)
+
+    @staticmethod
+    def _default_command_runner(args: list[str]):
+        process = subprocess.Popen(
+            args,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        stdout_thread = threading.Thread(
+            name="stdout",
+            target=MessageProcessor._log_stream_lines,
+            args=(process.stdout, logger.info),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            name="stderr",
+            target=MessageProcessor._log_stream_lines,
+            args=(process.stderr, logger.error),
+            daemon=True,
+        )
+
+        stdout_thread.start()
+        stderr_thread.start()
+        returncode = process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
+
+        return subprocess.CompletedProcess(args=args, returncode=returncode)
+
+    @staticmethod
+    def _log_stream_lines(
+        stream: Optional[TextIO],
+        log_line: Callable[[str], None],
+    ) -> None:
+        if stream is None:
+            return
+
+        with stream:
+            for line in stream:
+                log_line(line.rstrip("\r\n"))
+
+
+def command_worker(work_queue: queue.Queue, processor: MessageProcessor) -> None:
+    """Run queued command work items until a stop sentinel is received."""
+    while True:
+        item = work_queue.get()
+        try:
+            if item is STOP_WORKER:
+                return
+            processor.run_command(item.message, item.upload_data)
+        finally:
+            work_queue.task_done()

--- a/samples/python/file-agent/file-agent/pyproject.toml
+++ b/samples/python/file-agent/file-agent/pyproject.toml
@@ -1,0 +1,65 @@
+#
+# file-agent Python package metadata.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "file-agent"
+version = "0.1.0"
+description = "OCI IoT Platform file upload agent"
+requires-python = ">=3.12"
+dependencies = [
+  "click~=8.2.0",
+  "oci~=2.0,>=2.164",
+  "oracledb>=3.4.1",
+  "paho-mqtt>=2.1.0,<3",
+  "pydantic~=2.12.0",
+  "PyYAML~=6.0.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "black",
+  "pytest",
+  "ruff",
+]
+
+[project.scripts]
+file-agent = "file_agent.cli:cli"
+file-agent-device-demo = "file_agent.device_demo:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["file_agent*"]
+
+[tool.black]
+line-length = 88
+required-version = "26.3.1"
+target-version = ["py312"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["C4", "D", "E", "F", "I", "N", "W"]
+ignore = ["D100", "D103", "D212", "E203", "E402", "E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["file_agent"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/samples/python/file-agent/file-agent/tests/test_cli.py
+++ b/samples/python/file-agent/file-agent/tests/test_cli.py
@@ -1,0 +1,165 @@
+#
+# Tests for the file-agent CLI.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+from click.testing import CliRunner
+
+import file_agent.cli as cli_module
+from file_agent.cli import cli
+
+
+def test_cli_exposes_expected_commands():
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "subscribe" in result.output
+    assert "unsubscribe" in result.output
+    assert "monitor" in result.output
+    assert "janitor" in result.output
+
+
+def _write_config(tmp_path):
+    config_path = tmp_path / "file-agent.yaml"
+    config_path.write_text(
+        """
+oracledb:
+  thick_mode: false
+oci:
+  auth_type: InstancePrincipal
+iot:
+  domain_id: ocid1.iotdomain.oc1.eu-frankfurt-1.example
+  subscriber_name: file_agent
+  digital_twin:
+    instance_id: ocid1.iotdigitaltwininstance.oc1..device
+  content_path: file.commandDetails
+  response_endpoint: iot/v1/file/rsp
+object_storage:
+  namespace_name: namespace
+  bucket_name: uploads
+commands:
+  demo: /opt/demo.sh
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_subscribe_registers_db_aq_subscriber(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    calls = {}
+    domain_context = cli_module.IOTDomainContext(
+        domain_short_id="abc123",
+        db_connection_string="tcps:adb.example.com:1521/service",
+        db_token_scope="urn:oracle:db::id::scope",
+    )
+
+    monkeypatch.setattr(
+        cli_module,
+        "create_iot_client",
+        lambda config: calls.setdefault("iot_client", object()),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "derive_iot_domain_context",
+        lambda iot_client, iot_domain_id: calls.setdefault(
+            "derive_args", (iot_client, iot_domain_id)
+        )
+        and domain_context,
+    )
+
+    monkeypatch.setattr(
+        cli_module.iot_db,
+        "db_connect",
+        lambda **kwargs: calls.setdefault("db_connect_kwargs", kwargs) or object(),
+    )
+
+    def build_rule(**kwargs):
+        calls["rule_kwargs"] = kwargs
+        return "rule"
+
+    monkeypatch.setattr(cli_module.iot_db, "build_subscriber_rule", build_rule)
+    monkeypatch.setattr(
+        cli_module.iot_db,
+        "add_subscriber",
+        lambda **kwargs: calls.setdefault("add_kwargs", kwargs),
+    )
+    monkeypatch.setattr(
+        cli_module.iot_db,
+        "db_disconnect",
+        lambda connection: calls.setdefault("disconnected", connection),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(config_path), "subscribe"],
+    )
+
+    assert result.exit_code == 0
+    assert calls["derive_args"][1] == "ocid1.iotdomain.oc1.eu-frankfurt-1.example"
+    assert calls["db_connect_kwargs"]["db_connect_string"] == (
+        "tcps:adb.example.com:1521/service"
+    )
+    assert calls["db_connect_kwargs"]["db_token_scope"] == "urn:oracle:db::id::scope"
+    assert calls["add_kwargs"]["queue_name"] == "ABC123__IOT.NORMALIZED_DATA"
+    assert calls["add_kwargs"]["subscriber_name"] == "file_agent"
+    assert calls["add_kwargs"]["rule"] == "rule"
+    assert "registered" in result.output
+
+
+def test_janitor_list_outputs_file_agent_pars(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    par = type(
+        "PAR",
+        (),
+        {
+            "id": "par-id",
+            "name": "file-agent:device:txn-1",
+            "object_name": "device/txn-1/",
+            "time_created": "2026-04-28T12:00:00Z",
+        },
+    )()
+    service = type("Service", (), {"list_file_agent_pars": lambda self: [par]})()
+    monkeypatch.setattr(cli_module, "create_par_service", lambda config: service)
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config-file", str(config_path), "janitor", "list"],
+    )
+
+    assert result.exit_code == 0
+    assert "par-id" in result.output
+    assert "file-agent:device:txn-1" in result.output
+
+
+def test_janitor_prune_outputs_deleted_count(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    calls = {}
+
+    class FakeService:
+        def prune(self, min_age_minutes):
+            calls["min_age_minutes"] = min_age_minutes
+            return ["old-id"]
+
+    monkeypatch.setattr(cli_module, "create_par_service", lambda config: FakeService())
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--config-file",
+            str(config_path),
+            "janitor",
+            "prune",
+            "--min-age-minutes",
+            "60",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls["min_age_minutes"] == 60
+    assert "Deleted 1 PAR(s)" in result.output

--- a/samples/python/file-agent/file-agent/tests/test_config.py
+++ b/samples/python/file-agent/file-agent/tests/test_config.py
@@ -1,0 +1,146 @@
+#
+# Tests for file-agent configuration loading.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+import io
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from file_agent.config import AppConfig, load_config
+
+
+def _config_yaml(**overrides):
+    config = {
+        "oci": {"auth_type": "InstancePrincipal"},
+        "iot": {
+            "domain_id": "ocid1.iotdomain.oc1.eu-frankfurt-1.example",
+            "subscriber_name": "file_agent",
+            "digital_twin": {},
+        },
+        "object_storage": {
+            "namespace_name": "namespace",
+            "bucket_name": "uploads",
+            "max_ttl_minutes": 45,
+        },
+        "commands": {"demo": "/opt/demo.sh"},
+    }
+    config.update(overrides)
+    return config
+
+
+def test_load_config_reads_yaml_file_like_object():
+    config_file = io.StringIO("""
+oracledb:
+  thick_mode: true
+  thick_mode_lib_dir: /opt/oracle/instantclient
+oci:
+  auth_type: InstancePrincipal
+iot:
+  domain_id: ocid1.iotdomain.oc1.eu-frankfurt-1.example
+  subscriber_name: file_agent
+  digital_twin: {}
+object_storage:
+  namespace_name: namespace
+  bucket_name: uploads
+commands:
+  demo: /opt/demo.sh
+""")
+
+    config = load_config(config_file)
+
+    assert config.object_storage.max_ttl_minutes == 60
+    assert config.iot.response_endpoint == "iot/v1/file/rsp"
+    assert config.iot.domain_id == "ocid1.iotdomain.oc1.eu-frankfurt-1.example"
+    assert config.oracledb.thick_mode is True
+    assert config.oracledb.thick_mode_lib_dir == "/opt/oracle/instantclient"
+    assert config.commands == {"demo": "/opt/demo.sh"}
+
+
+def test_load_config_allows_absent_oracledb_section():
+    config_file = io.StringIO("""
+oci:
+  auth_type: InstancePrincipal
+iot:
+  domain_id: ocid1.iotdomain.oc1.eu-frankfurt-1.example
+  subscriber_name: file_agent
+  digital_twin: {}
+object_storage:
+  namespace_name: namespace
+  bucket_name: uploads
+""")
+
+    config = load_config(config_file)
+
+    assert config.oracledb.thick_mode is False
+    assert config.oracledb.thick_mode_lib_dir is None
+
+
+def test_checked_in_config_template_loads_with_default_oci_auth():
+    repo_root = Path(__file__).resolve().parents[2]
+    template = (repo_root / "file-agent-config.yaml").read_text(encoding="utf-8")
+    config_file = io.StringIO(
+        template.replace(
+            "ocid1.iotdomain.oc1.<region>...",
+            "ocid1.iotdomain.oc1.eu-frankfurt-1.example",
+        )
+        .replace("Object Storage namespace", "namespace")
+        .replace("Upload bucket", "uploads")
+    )
+
+    config = load_config(config_file)
+
+    assert config.oci.auth_type == "InstancePrincipal"
+
+
+def test_load_config_treats_null_oci_section_as_defaults():
+    config_file = io.StringIO("""
+oci:
+iot:
+  domain_id: ocid1.iotdomain.oc1.eu-frankfurt-1.example
+  subscriber_name: file_agent
+  digital_twin: {}
+object_storage:
+  namespace_name: namespace
+  bucket_name: uploads
+""")
+
+    config = load_config(config_file)
+
+    assert config.oci.auth_type == "InstancePrincipal"
+
+
+def test_digital_twin_filter_accepts_only_one_identifier():
+    raw_config = _config_yaml(
+        iot={
+            "domain_id": "ocid1.iotdomain.oc1.eu-frankfurt-1.example",
+            "subscriber_name": "file_agent",
+            "digital_twin": {
+                "instance_id": "ocid1.iotdigitaltwininstance.oc1..example",
+                "display_name": "device-1",
+            },
+        }
+    )
+
+    with pytest.raises(ValidationError, match="Only one of"):
+        AppConfig.model_validate(raw_config)
+
+
+def test_object_storage_ttl_must_be_positive():
+    raw_config = _config_yaml(
+        object_storage={
+            "namespace_name": "namespace",
+            "bucket_name": "uploads",
+            "max_ttl_minutes": 0,
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(raw_config)

--- a/samples/python/file-agent/file-agent/tests/test_demo_command.py
+++ b/samples/python/file-agent/file-agent/tests/test_demo_command.py
@@ -1,0 +1,94 @@
+#
+# Tests for the demo command script.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_COMMAND = REPO_ROOT / "commands" / "demo.sh"
+
+
+def _sample_message(**parameters):
+    return {
+        "message_id": "0102",
+        "digital_twin_instance_id": "ocid1.iotdigitaltwininstance.oc1..device",
+        "digital_twin_display_name": "demo-device",
+        "time_observed": "2026-04-29T19:00:00Z",
+        "content_path": "file.commandDetails",
+        "request": {
+            "op": "complete-upload",
+            "id": "txn-1",
+            "data": {
+                "command": "demo",
+                "parameters": {"artifacts": ["reads.fastq"], **parameters},
+            },
+        },
+    }
+
+
+def _run_demo(message, **kwargs):
+    return subprocess.run(
+        [str(DEMO_COMMAND), message],
+        capture_output=True,
+        check=False,
+        text=True,
+        **kwargs,
+    )
+
+
+def test_demo_command_displays_message_payload():
+    result = _run_demo(json.dumps(_sample_message(sleep=0)))
+
+    assert result.returncode == 0
+    assert "demo.sh: Message ID   : 0102" in result.stdout
+    assert "demo.sh: Instance ID  : ocid1.iotdigitaltwininstance.oc1..device" in (
+        result.stdout
+    )
+    assert "demo.sh: Request Id: txn-1" in result.stdout
+    assert '"artifacts": [' in result.stdout
+    assert "demo.sh: sleeping for 0 seconds" in result.stdout
+    assert "demo.sh: Done" in result.stdout
+    assert result.stderr == ""
+
+
+def test_demo_command_rejects_invalid_json():
+    result = _run_demo("not-json")
+
+    assert result.returncode == 1
+    assert "demo.sh: invalid message JSON" in result.stderr
+    assert "demo.sh: Done" not in result.stdout
+
+
+def test_demo_command_rejects_invalid_sleep_parameter():
+    result = _run_demo(json.dumps(_sample_message(sleep="not-a-number")))
+
+    assert result.returncode == 1
+    assert "demo.sh: parameters.sleep must be a non-negative number" in result.stderr
+    assert "demo.sh: Done" not in result.stdout
+
+
+def test_demo_command_reports_missing_jq(tmp_path):
+    bash = shutil.which("bash")
+    assert bash is not None
+    env = {**os.environ, "PATH": str(tmp_path)}
+
+    result = subprocess.run(
+        [bash, str(DEMO_COMMAND), json.dumps(_sample_message())],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 127
+    assert "demo.sh: jq is required" in result.stderr

--- a/samples/python/file-agent/file-agent/tests/test_device_demo.py
+++ b/samples/python/file-agent/file-agent/tests/test_device_demo.py
@@ -1,0 +1,156 @@
+#
+# Tests for the file-agent device demo.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+from pathlib import Path
+
+from file_agent import device_demo
+
+
+class _FakeMQTTModule:
+    MQTTv311 = "MQTTv311"
+
+    class CallbackAPIVersion:
+        VERSION2 = "VERSION2"
+
+    class Client:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.password = None
+            self.tls_context = None
+            self.username = None
+            self.on_connect = None
+            self.on_disconnect = None
+            self.on_message = None
+            self.on_subscribe = None
+
+        def username_pw_set(self, username, password):
+            self.username = username
+            self.password = password
+
+        def tls_set_context(self, context):
+            self.tls_context = context
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def getcode(self):
+        return self.status
+
+
+def test_configure_mqtt_client_uses_tls_and_persistent_session():
+    client = device_demo.configure_mqtt_client(
+        client_id="device-demo",
+        username="mqtt-user",
+        password="mqtt-password",
+        mqtt_module=_FakeMQTTModule,
+    )
+
+    assert client.kwargs["callback_api_version"] == "VERSION2"
+    assert client.kwargs["client_id"] == "device-demo"
+    assert client.kwargs["clean_session"] is False
+    assert client.kwargs["protocol"] == "MQTTv311"
+    assert client.username == "mqtt-user"
+    assert client.password == "mqtt-password"
+    assert client.tls_context is not None
+    assert client.on_connect is None
+    assert client.on_disconnect is None
+    assert client.on_message is None
+    assert client.on_subscribe is None
+
+
+def test_parse_args_defaults_client_id_to_username():
+    config = device_demo.parse_args(["mqtt.example.com", "mqtt-user", "secret"])
+
+    assert config.client_id == "mqtt-user"
+
+
+def test_prepare_upload_payload_contains_transaction_and_ttl():
+    assert device_demo.prepare_upload_payload("txn-1", ttl_minutes=30) == {
+        "op": "prepare-upload",
+        "id": "txn-1",
+        "data": {"ttl": 30},
+    }
+
+
+def test_mqtt_host_accepts_bare_host_or_endpoint_url():
+    assert device_demo.mqtt_host("mqtt.example.com") == "mqtt.example.com"
+    assert device_demo.mqtt_host("mqtt.example.com:8883") == "mqtt.example.com"
+    assert device_demo.mqtt_host("mqtts://mqtt.example.com:8883") == (
+        "mqtt.example.com"
+    )
+
+
+def test_complete_upload_payload_passes_uploaded_file_name_as_artifact():
+    payload = device_demo.complete_upload_payload(
+        transaction_id="txn-1",
+        command="demo",
+        file_name="reads fastq.txt",
+    )
+
+    assert payload == {
+        "op": "complete-upload",
+        "id": "txn-1",
+        "data": {
+            "command": "demo",
+            "parameters": {
+                "artifacts": ["reads fastq.txt"],
+            },
+        },
+    }
+
+
+def test_object_upload_url_appends_quoted_file_name():
+    upload_url = "https://objectstorage.example/p/token/device/txn-1/"
+
+    assert device_demo.object_upload_url(upload_url, "reads fastq.txt") == (
+        "https://objectstorage.example/p/token/device/txn-1/reads%20fastq.txt"
+    )
+
+
+def test_upload_file_puts_file_bytes_to_object_url(tmp_path):
+    file_path = tmp_path / "reads.fastq"
+    file_path.write_bytes(b"demo reads\n")
+    calls = []
+
+    def opener(request, timeout):
+        calls.append((request, timeout))
+        return _FakeHTTPResponse(200)
+
+    object_url = device_demo.upload_file(
+        upload_url="https://objectstorage.example/p/token/device/txn-1/",
+        file_path=file_path,
+        timeout_seconds=15,
+        opener=opener,
+    )
+
+    [(request, timeout)] = calls
+    assert (
+        object_url == "https://objectstorage.example/p/token/device/txn-1/reads.fastq"
+    )
+    assert request.full_url == object_url
+    assert request.get_method() == "PUT"
+    assert request.data == b"demo reads\n"
+    assert request.headers["Content-type"] == "application/octet-stream"
+    assert timeout == 15
+
+
+def test_default_test_file_is_created_with_demo_content(tmp_path):
+    file_path = device_demo.create_default_test_file(tmp_path)
+
+    assert file_path == Path(tmp_path) / "file-agent-device-demo.txt"
+    assert "file-agent device demo upload" in file_path.read_text(encoding="utf-8")

--- a/samples/python/file-agent/file-agent/tests/test_iot_context.py
+++ b/samples/python/file-agent/file-agent/tests/test_iot_context.py
@@ -1,0 +1,67 @@
+#
+# Tests for OCI IoT domain context derivation.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+from types import SimpleNamespace
+
+import pytest
+
+from file_agent.iot_context import derive_iot_domain_context
+
+
+class _FakeIOTClient:
+    def __init__(self, domain, domain_group):
+        self.domain = domain
+        self.domain_group = domain_group
+        self.domain_ids = []
+        self.domain_group_ids = []
+
+    def get_iot_domain(self, iot_domain_id):
+        self.domain_ids.append(iot_domain_id)
+        return SimpleNamespace(data=self.domain)
+
+    def get_iot_domain_group(self, iot_domain_group_id):
+        self.domain_group_ids.append(iot_domain_group_id)
+        return SimpleNamespace(data=self.domain_group)
+
+
+def test_derive_iot_domain_context_reads_domain_and_parent_group():
+    domain = SimpleNamespace(
+        device_host="abc123.device.iot.eu-frankfurt-1.oci.oraclecloud.com",
+        iot_domain_group_id="ocid1.iotdomaingroup.oc1..group",
+    )
+    domain_group = SimpleNamespace(
+        db_connection_string="tcps:adb.example.com:1521/service",
+        db_token_scope="urn:oracle:db::id::scope",
+    )
+    client = _FakeIOTClient(domain, domain_group)
+
+    context = derive_iot_domain_context(
+        iot_client=client,
+        iot_domain_id="ocid1.iotdomain.oc1..domain",
+    )
+
+    assert client.domain_ids == ["ocid1.iotdomain.oc1..domain"]
+    assert client.domain_group_ids == ["ocid1.iotdomaingroup.oc1..group"]
+    assert context.domain_short_id == "abc123"
+    assert context.db_connection_string == "tcps:adb.example.com:1521/service"
+    assert context.db_token_scope == "urn:oracle:db::id::scope"
+
+
+def test_derive_iot_domain_context_rejects_incomplete_domain_response():
+    client = _FakeIOTClient(
+        domain=SimpleNamespace(device_host="", iot_domain_group_id=""),
+        domain_group=SimpleNamespace(),
+    )
+
+    with pytest.raises(ValueError, match="device_host"):
+        derive_iot_domain_context(
+            iot_client=client,
+            iot_domain_id="ocid1.iotdomain.oc1..domain",
+        )

--- a/samples/python/file-agent/file-agent/tests/test_iot_db.py
+++ b/samples/python/file-agent/file-agent/tests/test_iot_db.py
@@ -1,0 +1,159 @@
+#
+# Tests for Oracle DB/AQ IoT message handling.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+import queue
+from types import SimpleNamespace
+
+import pytest
+
+from file_agent import iot_db
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+        self.executed = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, statement, parameters=None):
+        self.executed.append((statement, parameters or {}))
+
+    def fetchone(self):
+        if self.rows:
+            return self.rows.pop(0)
+        return None
+
+    def callfunc(self, name, return_type, args):
+        return f"'{args[0]}'"
+
+    def callproc(self, name, keyword_parameters=None):
+        self.executed.append((name, keyword_parameters or {}))
+
+
+class _FakeConnection:
+    def __init__(self, rows=None, messages=None):
+        self.cursor_instance = _FakeCursor(rows)
+        self.messages = list(messages or [])
+        self.commits = 0
+        self.queue_instance = None
+
+    def cursor(self):
+        return self.cursor_instance
+
+    def queue(self, name, payload_type):
+        self.queue_instance = _FakeQueue(self.messages)
+        return self.queue_instance
+
+    def commit(self):
+        self.commits += 1
+
+
+class _FakeQueue:
+    def __init__(self, messages):
+        self.messages = messages
+        self.deqOptions = SimpleNamespace()
+
+    def deqone(self):
+        if not self.messages:
+            return None
+        return self.messages.pop(0)
+
+
+def _message(payload, msgid=b"\x01\x02"):
+    return SimpleNamespace(payload=payload, msgid=msgid)
+
+
+def _payload(value):
+    return {
+        "digitalTwinInstanceId": "ocid1.iotdigitaltwininstance.oc1..device",
+        "timeObserved": "2026-04-28T12:00:00Z",
+        "contentPath": "file.commandDetails",
+        "value": value,
+    }
+
+
+def test_build_subscriber_rule_filters_by_display_name_and_content_path():
+    connection = _FakeConnection(rows=[["ocid1.iotdigitaltwininstance.oc1..device"]])
+
+    rule = iot_db.build_subscriber_rule(
+        connection=connection,
+        iot_domain_short_id="abc123",
+        digital_twin_instance_id=None,
+        display_name="device-1",
+        content_path="file.commandDetails",
+    )
+
+    assert rule == (
+        'tab.user_data."digitalTwinInstanceId" = '
+        "'ocid1.iotdigitaltwininstance.oc1..device' and "
+        "tab.user_data.\"contentPath\" = 'file.commandDetails'"
+    )
+
+
+def test_build_subscriber_rule_rejects_unknown_display_name():
+    connection = _FakeConnection(rows=[])
+
+    with pytest.raises(ValueError, match="No such display name"):
+        iot_db.build_subscriber_rule(
+            connection=connection,
+            iot_domain_short_id="abc123",
+            digital_twin_instance_id=None,
+            display_name="missing",
+            content_path="file.commandDetails",
+        )
+
+
+def test_dequeue_messages_reports_invalid_payload_to_callback():
+    connection = _FakeConnection(
+        messages=[_message({"digitalTwinInstanceId": "ocid1.device"})]
+    )
+    invalid = []
+
+    iot_db.dequeue_messages(
+        connection=connection,
+        queue_name="ABC123__IOT.NORMALIZED_DATA",
+        subscriber_name="file_agent",
+        iot_domain_short_id="abc123",
+        message_queue=queue.Queue(),
+        invalid_message_handler=lambda instance_id, error: invalid.append(
+            (instance_id, error)
+        ),
+        max_messages=1,
+    )
+
+    assert connection.commits == 1
+    assert invalid[0][0] == "ocid1.device"
+
+
+def test_dequeue_messages_forwards_valid_payload_with_display_name():
+    payload = _payload({"op": "prepare-upload", "id": "txn-1", "data": {"ttl": 30}})
+    connection = _FakeConnection(rows=[["device-1"]], messages=[_message(payload)])
+    outbox = queue.Queue()
+
+    iot_db.dequeue_messages(
+        connection=connection,
+        queue_name="ABC123__IOT.NORMALIZED_DATA",
+        subscriber_name="file_agent",
+        iot_domain_short_id="abc123",
+        message_queue=outbox,
+        max_messages=1,
+    )
+
+    message = outbox.get_nowait()
+    assert message.message_id == "0102"
+    assert message.digital_twin_display_name == "device-1"
+    assert message.request.op == "prepare-upload"
+    assert message.request.id == "txn-1"
+    assert connection.queue_instance.deqOptions.consumername == "file_agent"

--- a/samples/python/file-agent/file-agent/tests/test_iot_raw.py
+++ b/samples/python/file-agent/file-agent/tests/test_iot_raw.py
@@ -1,0 +1,67 @@
+#
+# Tests for OCI IoT raw-command publishing.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+from file_agent.iot_raw import send_payload, send_response
+from file_agent.models import ProtocolResponse
+
+
+class _FakeIOTClient:
+    def __init__(self):
+        self.calls = []
+
+    def invoke_raw_command(
+        self, *, digital_twin_instance_id, invoke_raw_command_details
+    ):
+        self.calls.append((digital_twin_instance_id, invoke_raw_command_details))
+        return type("Response", (), {"status": 202, "data": None})()
+
+
+def test_send_response_invokes_raw_json_command_with_protocol_payload():
+    client = _FakeIOTClient()
+    response = ProtocolResponse(
+        op="prepare-upload",
+        id="txn-1",
+        data={
+            "upload_url": (
+                "https://objectstorage.example/p/token/"
+                "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+            )
+        },
+        code=200,
+        message="Upload prepared",
+    )
+
+    send_response(
+        iot_client=client,
+        digital_twin_instance_id="ocid1.iotdigitaltwininstance.oc1..device",
+        endpoint="iot/v1/file/rsp",
+        response=response,
+    )
+
+    [(digital_twin_instance_id, details)] = client.calls
+    assert digital_twin_instance_id == "ocid1.iotdigitaltwininstance.oc1..device"
+    assert details.request_endpoint == "iot/v1/file/rsp"
+    assert details.request_duration == "PT60M"
+    assert details.request_data == response.to_payload()
+
+
+def test_send_payload_allows_bad_request_without_protocol_envelope():
+    client = _FakeIOTClient()
+
+    send_payload(
+        iot_client=client,
+        digital_twin_instance_id="ocid1.iotdigitaltwininstance.oc1..device",
+        endpoint="iot/v1/file/rsp",
+        payload={"code": 400, "message": "Bad request"},
+    )
+
+    [(digital_twin_instance_id, details)] = client.calls
+    assert digital_twin_instance_id == "ocid1.iotdigitaltwininstance.oc1..device"
+    assert details.request_data == {"code": 400, "message": "Bad request"}

--- a/samples/python/file-agent/file-agent/tests/test_models.py
+++ b/samples/python/file-agent/file-agent/tests/test_models.py
@@ -1,0 +1,155 @@
+#
+# Tests for file-agent protocol models.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+import pytest
+from pydantic import ValidationError
+
+from file_agent.models import (
+    InboundMessage,
+    PARRequestData,
+    ProtocolRequest,
+    ProtocolResponse,
+    UploadRequestData,
+)
+
+
+def _message_payload(value):
+    return {
+        "digitalTwinInstanceId": "ocid1.iotdigitaltwininstance.oc1..device",
+        "timeObserved": "2026-04-28T12:00:00Z",
+        "contentPath": "file.commandDetails",
+        "value": value,
+    }
+
+
+def test_prepare_upload_request_exposes_ttl_data():
+    message = InboundMessage.model_validate(
+        _message_payload(
+            {
+                "op": "prepare-upload",
+                "id": "txn-1",
+                "data": {"ttl": 120},
+            }
+        )
+    )
+
+    assert message.request.op == "prepare-upload"
+    assert message.request.id == "txn-1"
+    assert PARRequestData.model_validate(message.request.data).ttl == 120
+
+
+def test_inbound_message_normalizes_camel_case_input_to_snake_case_fields():
+    message = InboundMessage.model_validate(
+        _message_payload({"op": "prepare-upload", "id": "txn-1", "data": {}})
+    )
+
+    assert message.digital_twin_instance_id == (
+        "ocid1.iotdigitaltwininstance.oc1..device"
+    )
+    assert message.time_observed == "2026-04-28T12:00:00Z"
+    assert message.content_path == "file.commandDetails"
+    assert message.request.id == "txn-1"
+
+    serialized = message.model_dump(by_alias=True)
+
+    assert serialized["digital_twin_instance_id"] == (
+        "ocid1.iotdigitaltwininstance.oc1..device"
+    )
+    assert serialized["time_observed"] == "2026-04-28T12:00:00Z"
+    assert serialized["content_path"] == "file.commandDetails"
+    assert serialized["request"]["id"] == "txn-1"
+    assert "digitalTwinInstanceId" not in serialized
+    assert "timeObserved" not in serialized
+    assert "contentPath" not in serialized
+    assert "value" not in serialized
+
+
+def test_inbound_message_rejects_snake_case_field_names_for_aliased_fields():
+    payload = {
+        "digital_twin_instance_id": "ocid1.iotdigitaltwininstance.oc1..device",
+        "time_observed": "2026-04-28T12:00:00Z",
+        "content_path": "file.commandDetails",
+        "request": {"op": "prepare-upload", "id": "txn-1", "data": {"ttl": 120}},
+    }
+
+    with pytest.raises(ValidationError):
+        InboundMessage.model_validate(payload)
+
+
+def test_complete_upload_request_allows_optional_command():
+    request = ProtocolRequest.model_validate(
+        {
+            "op": "complete-upload",
+            "id": "txn-1",
+            "data": {
+                "command": "demo",
+                "parameters": {"artifacts": ["reads.fastq"]},
+            },
+        }
+    )
+
+    upload_data = UploadRequestData.model_validate(request.data)
+
+    assert upload_data.command == "demo"
+    assert upload_data.parameters == {"artifacts": ["reads.fastq"]}
+
+
+def test_unknown_operation_is_rejected():
+    with pytest.raises(ValidationError):
+        ProtocolRequest.model_validate({"op": "bad-op", "id": "txn-1", "data": {}})
+
+
+@pytest.mark.parametrize(
+    "transaction_id",
+    [
+        "txn/1",
+        "txn?1",
+        "txn#1",
+        "txn%2f1",
+        ".",
+        "..",
+        "txn 1",
+        "txn\n1",
+        "x" * 129,
+    ],
+)
+def test_transaction_id_rejects_unsafe_path_and_url_components(transaction_id):
+    with pytest.raises(ValidationError):
+        ProtocolRequest.model_validate(
+            {"op": "prepare-upload", "id": transaction_id, "data": {}}
+        )
+
+
+def test_protocol_response_payload_matches_readme_shape():
+    response = ProtocolResponse(
+        op="prepare-upload",
+        id="txn-1",
+        data={
+            "upload_url": (
+                "https://objectstorage.example/p/token/"
+                "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+            )
+        },
+        code=200,
+        message="Upload prepared",
+    )
+
+    assert response.to_payload() == {
+        "op": "prepare-upload",
+        "id": "txn-1",
+        "data": {
+            "upload_url": (
+                "https://objectstorage.example/p/token/"
+                "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+            )
+        },
+        "code": 200,
+        "message": "Upload prepared",
+    }

--- a/samples/python/file-agent/file-agent/tests/test_object_storage.py
+++ b/samples/python/file-agent/file-agent/tests/test_object_storage.py
@@ -1,0 +1,209 @@
+#
+# Tests for Object Storage PAR lifecycle helpers.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+from datetime import datetime, timedelta, timezone
+
+from oci.object_storage.models import CreatePreauthenticatedRequestDetails
+
+from file_agent.object_storage import PARService
+
+
+class _FakeObjectStorageClient:
+    def __init__(self):
+        self.base_client = type(
+            "BaseClient",
+            (),
+            {"endpoint": "https://objectstorage.eu-frankfurt-1.oraclecloud.com"},
+        )()
+        self.created = []
+        self.deleted = []
+        self.summaries = []
+        self.summary_pages = None
+        self.list_calls = []
+
+    def create_preauthenticated_request(
+        self, namespace_name, bucket_name, create_preauthenticated_request_details
+    ):
+        self.created.append(
+            (namespace_name, bucket_name, create_preauthenticated_request_details)
+        )
+        return type(
+            "Response",
+            (),
+            {
+                "data": type(
+                    "PAR",
+                    (),
+                    {
+                        "id": "par-id",
+                        "access_uri": "/p/token/n/namespace/b/uploads/o/",
+                    },
+                )()
+            },
+        )()
+
+    def list_preauthenticated_requests(self, namespace_name, bucket_name, **kwargs):
+        self.list_calls.append((namespace_name, bucket_name, kwargs))
+        if self.summary_pages is None:
+            return type("Response", (), {"data": self.summaries})()
+
+        page = kwargs.get("page")
+        page_index = 0 if page is None else int(page)
+        next_page = (
+            str(page_index + 1) if page_index + 1 < len(self.summary_pages) else None
+        )
+        return type(
+            "Response",
+            (),
+            {"data": self.summary_pages[page_index], "next_page": next_page},
+        )()
+
+    def delete_preauthenticated_request(self, namespace_name, bucket_name, par_id):
+        self.deleted.append((namespace_name, bucket_name, par_id))
+
+
+def _summary(name, par_id="par-id", created=None):
+    return type(
+        "Summary",
+        (),
+        {
+            "id": par_id,
+            "name": name,
+            "time_created": created
+            or datetime(2026, 4, 28, 10, 0, tzinfo=timezone.utc),
+        },
+    )()
+
+
+def test_stage_upload_caps_ttl_and_creates_write_only_prefix_par():
+    now = datetime(2026, 4, 28, 12, 0, tzinfo=timezone.utc)
+    client = _FakeObjectStorageClient()
+    service = PARService(
+        object_storage_client=client,
+        namespace_name="namespace",
+        bucket_name="uploads",
+        max_ttl_minutes=30,
+        now=lambda: now,
+    )
+
+    result = service.stage_upload(
+        digital_twin_instance_id="ocid1.iotdigitaltwininstance.oc1..device",
+        transaction_id="txn-1",
+        requested_ttl_minutes=120,
+    )
+
+    assert result.par_id == "par-id"
+    assert result.upload_url == (
+        "https://objectstorage.eu-frankfurt-1.oraclecloud.com"
+        "/p/token/n/namespace/b/uploads/o/"
+        "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+    )
+    assert result.object_prefix == "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+
+    [(namespace_name, bucket_name, details)] = client.created
+    assert namespace_name == "namespace"
+    assert bucket_name == "uploads"
+    assert isinstance(details, CreatePreauthenticatedRequestDetails)
+    assert details.name == "file-agent:ocid1.iotdigitaltwininstance.oc1..device:txn-1"
+    assert details.object_name == "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+    assert details.access_type == "AnyObjectWrite"
+    assert details.time_expires == now + timedelta(minutes=30)
+
+
+def test_complete_upload_deletes_matching_file_agent_par():
+    client = _FakeObjectStorageClient()
+    client.summaries = [
+        _summary("unrelated", "other-id"),
+        _summary("file-agent:ocid1.iotdigitaltwininstance.oc1..device:txn-1", "par-id"),
+    ]
+    service = PARService(
+        object_storage_client=client,
+        namespace_name="namespace",
+        bucket_name="uploads",
+    )
+
+    deleted = service.complete_upload(
+        digital_twin_instance_id="ocid1.iotdigitaltwininstance.oc1..device",
+        transaction_id="txn-1",
+    )
+
+    assert deleted is True
+    assert client.deleted == [("namespace", "uploads", "par-id")]
+
+
+def test_complete_upload_checks_all_par_list_pages():
+    client = _FakeObjectStorageClient()
+    client.summary_pages = [
+        [_summary("file-agent:device:txn-0", "first-page-id")],
+        [
+            _summary(
+                "file-agent:ocid1.iotdigitaltwininstance.oc1..device:txn-1", "par-id"
+            )
+        ],
+    ]
+    service = PARService(
+        object_storage_client=client,
+        namespace_name="namespace",
+        bucket_name="uploads",
+    )
+
+    deleted = service.complete_upload(
+        digital_twin_instance_id="ocid1.iotdigitaltwininstance.oc1..device",
+        transaction_id="txn-1",
+    )
+
+    assert deleted is True
+    assert client.deleted == [("namespace", "uploads", "par-id")]
+    assert [call[2].get("page") for call in client.list_calls] == [None, "1"]
+
+
+def test_prune_deletes_only_file_agent_pars_older_than_threshold():
+    now = datetime(2026, 4, 28, 12, 0, tzinfo=timezone.utc)
+    client = _FakeObjectStorageClient()
+    client.summaries = [
+        _summary("file-agent:device:old", "old-id", now - timedelta(hours=3)),
+        _summary("file-agent:device:new", "new-id", now - timedelta(minutes=10)),
+        _summary("manual:device:old", "manual-id", now - timedelta(hours=3)),
+    ]
+    service = PARService(
+        object_storage_client=client,
+        namespace_name="namespace",
+        bucket_name="uploads",
+        now=lambda: now,
+    )
+
+    pruned = service.prune(min_age_minutes=60)
+
+    assert pruned == ["old-id"]
+    assert client.deleted == [("namespace", "uploads", "old-id")]
+
+
+def test_prune_checks_all_par_list_pages():
+    now = datetime(2026, 4, 28, 12, 0, tzinfo=timezone.utc)
+    client = _FakeObjectStorageClient()
+    client.summary_pages = [
+        [_summary("file-agent:device:first", "first-id", now - timedelta(hours=3))],
+        [_summary("file-agent:device:second", "second-id", now - timedelta(hours=3))],
+    ]
+    service = PARService(
+        object_storage_client=client,
+        namespace_name="namespace",
+        bucket_name="uploads",
+        now=lambda: now,
+    )
+
+    pruned = service.prune(min_age_minutes=60)
+
+    assert pruned == ["first-id", "second-id"]
+    assert client.deleted == [
+        ("namespace", "uploads", "first-id"),
+        ("namespace", "uploads", "second-id"),
+    ]
+    assert [call[2].get("page") for call in client.list_calls] == [None, "1"]

--- a/samples/python/file-agent/file-agent/tests/test_packaging_layout.py
+++ b/samples/python/file-agent/file-agent/tests/test_packaging_layout.py
@@ -1,0 +1,35 @@
+#
+# Tests for Python package layout.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+import tomllib
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PROJECT_ROOT.parent
+
+
+def test_python_project_metadata_lives_under_app_directory():
+    assert not (REPO_ROOT / "pyproject.toml").exists()
+    assert (PROJECT_ROOT / "pyproject.toml").is_file()
+
+
+def test_package_source_lives_under_app_directory():
+    assert not (REPO_ROOT / "file_agent").exists()
+    assert (PROJECT_ROOT / "file_agent").is_dir()
+
+
+def test_setuptools_discovers_only_file_agent_package_directory():
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    package_find = pyproject["tool"]["setuptools"]["packages"]["find"]
+
+    assert package_find["where"] == ["."]
+    assert package_find["include"] == ["file_agent*"]

--- a/samples/python/file-agent/file-agent/tests/test_processor.py
+++ b/samples/python/file-agent/file-agent/tests/test_processor.py
@@ -1,0 +1,237 @@
+#
+# Tests for file-agent protocol processing.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+import logging
+import sys
+from types import SimpleNamespace
+
+from file_agent.models import InboundMessage
+from file_agent.processor import MessageProcessor
+
+
+class _FakePARService:
+    def __init__(self):
+        self.stage_result = SimpleNamespace(
+            par_id="par-id",
+            upload_url=(
+                "https://objectstorage.example/p/token/"
+                "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+            ),
+            object_prefix="ocid1.iotdigitaltwininstance.oc1..device/txn-1/",
+        )
+        self.stage_exception = None
+        self.complete_result = True
+        self.stage_calls = []
+        self.complete_calls = []
+
+    def stage_upload(
+        self, digital_twin_instance_id, transaction_id, requested_ttl_minutes
+    ):
+        self.stage_calls.append(
+            (digital_twin_instance_id, transaction_id, requested_ttl_minutes)
+        )
+        if self.stage_exception:
+            raise self.stage_exception
+        return self.stage_result
+
+    def complete_upload(self, digital_twin_instance_id, transaction_id):
+        self.complete_calls.append((digital_twin_instance_id, transaction_id))
+        return self.complete_result
+
+
+def _message(value):
+    return InboundMessage.model_validate(
+        {
+            "digitalTwinInstanceId": "ocid1.iotdigitaltwininstance.oc1..device",
+            "timeObserved": "2026-04-28T12:00:00Z",
+            "contentPath": "file.commandDetails",
+            "value": value,
+        }
+    )
+
+
+def _processor(par_service=None, commands=None, runner=None):
+    responses = []
+    processor = MessageProcessor(
+        par_service=par_service or _FakePARService(),
+        commands=commands or {},
+        responder=lambda message, response: responses.append(response.to_payload()),
+        command_runner=runner,
+    )
+    return processor, responses
+
+
+def test_prepare_upload_creates_par_and_returns_upload_url():
+    par_service = _FakePARService()
+    processor, responses = _processor(par_service=par_service)
+
+    processor.handle_message(
+        _message({"op": "prepare-upload", "id": "txn-1", "data": {"ttl": 120}})
+    )
+
+    assert par_service.stage_calls == [
+        ("ocid1.iotdigitaltwininstance.oc1..device", "txn-1", 120)
+    ]
+    assert responses == [
+        {
+            "op": "prepare-upload",
+            "id": "txn-1",
+            "data": {
+                "upload_url": (
+                    "https://objectstorage.example/p/token/"
+                    "ocid1.iotdigitaltwininstance.oc1..device/txn-1/"
+                )
+            },
+            "code": 200,
+            "message": "Upload prepared",
+        }
+    ]
+
+
+def test_prepare_upload_service_error_sends_500():
+    par_service = _FakePARService()
+    par_service.stage_exception = RuntimeError("boom")
+    processor, responses = _processor(par_service=par_service)
+
+    processor.handle_message(
+        _message({"op": "prepare-upload", "id": "txn-1", "data": {"ttl": 60}})
+    )
+
+    assert responses[-1]["code"] == 500
+    assert responses[-1]["message"] == "Upload preparation failed"
+
+
+def test_complete_upload_deletes_par_and_completes_when_no_command_requested():
+    par_service = _FakePARService()
+    processor, responses = _processor(par_service=par_service)
+
+    processor.handle_message(
+        _message({"op": "complete-upload", "id": "txn-1", "data": {}})
+    )
+
+    assert par_service.complete_calls == [
+        ("ocid1.iotdigitaltwininstance.oc1..device", "txn-1")
+    ]
+    assert responses == [
+        {
+            "op": "complete-upload",
+            "id": "txn-1",
+            "data": {},
+            "code": 200,
+            "message": "Process completed",
+        }
+    ]
+
+
+def test_complete_upload_rejects_missing_prepared_upload():
+    par_service = _FakePARService()
+    par_service.complete_result = False
+    processor, responses = _processor(par_service=par_service)
+
+    processor.handle_message(
+        _message({"op": "complete-upload", "id": "txn-1", "data": {}})
+    )
+
+    assert responses[-1]["code"] == 422
+    assert responses[-1]["message"] == "No prepared upload"
+
+
+def test_complete_upload_rejects_unknown_command_after_par_cleanup():
+    par_service = _FakePARService()
+    processor, responses = _processor(par_service=par_service, commands={})
+
+    processor.handle_message(
+        _message(
+            {
+                "op": "complete-upload",
+                "id": "txn-1",
+                "data": {"command": "missing", "parameters": {}},
+            }
+        )
+    )
+
+    assert par_service.complete_calls == [
+        ("ocid1.iotdigitaltwininstance.oc1..device", "txn-1")
+    ]
+    assert responses[-1]["code"] == 422
+    assert responses[-1]["message"] == "Invalid command"
+
+
+def test_complete_upload_with_command_sends_queued_started_completed():
+    runner_calls = []
+
+    def runner(args):
+        runner_calls.append(args)
+        return SimpleNamespace(returncode=0)
+
+    processor, responses = _processor(
+        commands={"demo": "/opt/demo.sh"},
+        runner=runner,
+    )
+
+    processor.handle_message(
+        _message(
+            {
+                "op": "complete-upload",
+                "id": "txn-1",
+                "data": {"command": "demo", "parameters": {"artifacts": ["x"]}},
+            }
+        )
+    )
+
+    assert [response["code"] for response in responses] == [202, 201, 200]
+    assert [response["message"] for response in responses] == [
+        "Process queued",
+        "Process started",
+        "Process completed",
+    ]
+    assert runner_calls[0][0] == "/opt/demo.sh"
+    assert '"op":"complete-upload"' in runner_calls[0][1]
+
+
+def test_default_command_runner_logs_stdout_and_stderr_lines(caplog):
+    caplog.set_level(logging.INFO, logger="file_agent.processor")
+
+    result = MessageProcessor._default_command_runner(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "print('stdout line 1')\n"
+                "print('stdout line 2')\n"
+                "print('stderr line 1', file=sys.stderr)\n"
+                "print('stderr line 2', file=sys.stderr)\n"
+            ),
+        ]
+    )
+
+    stdout_records = [
+        record
+        for record in caplog.records
+        if record.name == "file_agent.processor" and record.levelno == logging.INFO
+    ]
+    stderr_records = [
+        record
+        for record in caplog.records
+        if record.name == "file_agent.processor" and record.levelno == logging.ERROR
+    ]
+
+    assert result.returncode == 0
+    assert [record.message for record in stdout_records] == [
+        "stdout line 1",
+        "stdout line 2",
+    ]
+    assert [record.threadName for record in stdout_records] == ["stdout", "stdout"]
+    assert [record.message for record in stderr_records] == [
+        "stderr line 1",
+        "stderr line 2",
+    ]
+    assert [record.threadName for record in stderr_records] == ["stderr", "stderr"]

--- a/samples/python/file-agent/images/file-agent.png
+++ b/samples/python/file-agent/images/file-agent.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713dee3ceebabe982697ece1e581cf517a03ba72d2c1f2f609c23202114afa29
+size 37854


### PR DESCRIPTION
## Summary

Add a new Python file upload agent sample for OCI IoT Platform.

The sample demonstrates an end-to-end file upload workflow where an IoT device requests an upload over MQTT, a backend agent consumes normalized IoT database queue messages, creates short-lived OCI Object Storage PAR upload URLs, responds through raw IoT commands, and optionally runs post-processing after upload completion.

Also updates the top-level README with a new **End-to-End Samples** section for the M5Stack CoreS3 and File Upload Agent samples.

## Changes

- Add `samples/python/file-agent` sample with:
  - DTDL models and adapter examples
  - File agent CLI
  - MQTT device demo
  - Object Storage PAR handling
  - IoT raw command responses
  - DB/AQ queue consumption
  - Configuration template and README
- Add unit tests for the file agent package
- Add workflow diagram image tracked through Git LFS
- Move the M5Stack description into the new README end-to-end samples section

## Validation

- `~/.venv/iot/bin/python -m pytest -q samples/python/file-agent/file-agent/tests`
  - `60 passed`
- `~/.venv/pre-commit/bin/pre-commit run --all-files`
  - Passed
- Commit hook pre-commit checks
  - Passed
- Verified `samples/python/file-agent/images/file-agent.png` is committed as a Git LFS pointer

---

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>