### PR TITLE
Fix Podman Compose runtime for Node-RED gateway sample

### DIFF
--- a/samples/node/node-red-gateway/README.md
+++ b/samples/node/node-red-gateway/README.md
@@ -276,8 +276,11 @@ docker compose up
 Start with Podman Compose:
 
 ```sh
-podman compose up
+podman compose -f podman-compose.yaml up
 ```
+
+The Podman Compose file includes SELinux relabeling for bind mounts and `:U` on
+the Node-RED data volume so the container user can seed `/data`.
 
 Start with Podman Quadlet by following [quadlet/README.md](quadlet/README.md).
 The Quadlet files use the same environment keys.
@@ -467,6 +470,34 @@ Wrong gateway credentials:
 - Confirm `flows/flows_cred.template.json` still contains the
   `${IOT_GATEWAY_EXTERNAL_KEY}` and `${IOT_GATEWAY_SECRET}` placeholders if you
   are reseeding the Node-RED data volume.
+
+Podman Compose reports permission denied while seeding `/data`:
+
+- Use `podman compose -f podman-compose.yaml up`.
+- If the volume was created by an earlier run, remove the old Podman Compose
+  volume and start again:
+
+  ```sh
+  podman compose -f podman-compose.yaml down
+  podman volume rm oci-iot-node-red-compose-data
+  podman compose -f podman-compose.yaml up
+  ```
+
+Podman Compose reports local MQTT connection failures to `mqtt://mosquitto:1883`:
+
+- Recreate the Podman Compose network so the explicit `mosquitto` alias is
+  applied:
+
+  ```sh
+  podman compose -f podman-compose.yaml down
+  podman compose -f podman-compose.yaml up
+  ```
+
+- Verify the alias from the Node-RED container:
+
+  ```sh
+  podman compose -f podman-compose.yaml exec node-red getent hosts mosquitto
+  ```
 
 Indirect device telemetry not updating:
 

--- a/samples/node/node-red-gateway/podman-compose.yaml
+++ b/samples/node/node-red-gateway/podman-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  mosquitto:
+    image: eclipse-mosquitto:2
+    ports:
+      - "127.0.0.1:1883:1883"
+    volumes:
+      - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro,Z
+    networks:
+      gateway:
+        aliases:
+          - mosquitto
+
+  node-red:
+    image: nodered/node-red:latest
+    entrypoint: /bin/bash
+    command: /opt/oci-iot-node-red/seed-sample.sh
+    ports:
+      - "127.0.0.1:1880:1880"
+    depends_on:
+      - mosquitto
+    env_file:
+      - .env
+    volumes:
+      - node-red-data:/data:U
+      - ./nodered/seed-sample.sh:/opt/oci-iot-node-red/seed-sample.sh:ro,Z
+      - ./flows/flows.json:/opt/oci-iot-node-red/flows.json:ro,Z
+      - ./flows/flows_cred.template.json:/opt/oci-iot-node-red/flows_cred.json:ro,Z
+      - ./nodered/settings.js:/data/settings.js:ro,Z
+      - ./nodered/package.json:/data/package.json:ro,Z
+    networks:
+      - gateway
+
+networks:
+  gateway:
+
+volumes:
+  node-red-data:
+    name: oci-iot-node-red-compose-data

--- a/samples/node/node-red-gateway/tests/validate-sample.mjs
+++ b/samples/node/node-red-gateway/tests/validate-sample.mjs
@@ -9,6 +9,7 @@ const sampleDir = dirname(testDir);
 
 const requiredFiles = [
   'docker-compose.yaml',
+  'podman-compose.yaml',
   'README.md',
   '.env.example',
   'data/gateway-model.json',
@@ -491,6 +492,28 @@ for (const volume of [
 }
 assertMatches(dockerCompose, /^volumes:\n {2}node-red-data:\s*$/m, 'docker-compose.yaml', 'must define node-red-data volume');
 assertMatches(composeNodeRed, /networks:\n\s+- gateway/m, 'docker-compose.yaml node-red service', 'must use gateway network');
+
+const podmanCompose = await readText('podman-compose.yaml');
+assertContains(podmanCompose, 'services:', 'podman-compose.yaml');
+assertContains(podmanCompose, 'image: eclipse-mosquitto:2', 'podman-compose.yaml');
+assertContains(podmanCompose, './mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro,Z', 'podman-compose.yaml');
+assertContains(podmanCompose, 'aliases:', 'podman-compose.yaml');
+assertContains(podmanCompose, '- mosquitto', 'podman-compose.yaml');
+assertContains(podmanCompose, 'image: nodered/node-red:latest', 'podman-compose.yaml');
+assertContains(podmanCompose, 'entrypoint: /bin/bash', 'podman-compose.yaml');
+assertContains(podmanCompose, 'command: /opt/oci-iot-node-red/seed-sample.sh', 'podman-compose.yaml');
+assertContains(podmanCompose, 'node-red-data:/data:U', 'podman-compose.yaml');
+assertContains(podmanCompose, 'name: oci-iot-node-red-compose-data', 'podman-compose.yaml');
+for (const volume of [
+  './nodered/seed-sample.sh:/opt/oci-iot-node-red/seed-sample.sh:ro,Z',
+  './flows/flows.json:/opt/oci-iot-node-red/flows.json:ro,Z',
+  './flows/flows_cred.template.json:/opt/oci-iot-node-red/flows_cred.json:ro,Z',
+  './nodered/settings.js:/data/settings.js:ro,Z',
+  './nodered/package.json:/data/package.json:ro,Z',
+]) {
+  assertContains(podmanCompose, volume, 'podman-compose.yaml');
+}
+assertMatches(podmanCompose, /^volumes:\n {2}node-red-data:\s*$/m, 'podman-compose.yaml', 'must define node-red-data volume');
 
 const mosquittoConfig = await readText('mosquitto/mosquitto.conf');
 assertContains(mosquittoConfig, 'listener 1883 0.0.0.0', 'mosquitto.conf');
@@ -980,6 +1003,9 @@ for (const expected of [
   'Certificate-based gateway authentication',
   'cp .env.example .env',
   'docker compose up',
+  'podman compose -f podman-compose.yaml up',
+  'podman volume rm oci-iot-node-red-compose-data',
+  'podman compose -f podman-compose.yaml exec node-red getent hosts mosquitto',
   'http://127.0.0.1:1880',
   'localhost by default',
   'Mosquitto port binding',
@@ -1001,7 +1027,7 @@ for (const expected of [
   '--gateways',
   'invoke-raw-json-command',
   'docker compose up',
-  'podman compose up',
+  'podman compose -f podman-compose.yaml up',
   'Quadlet',
   'devices/m5-01/telemetry',
   'm5/m5-01/cmd',


### PR DESCRIPTION
Adds a Podman-specific Compose file for the Node-RED gateway sample.

This fixes rootless Podman Compose runtime issues by:
- Adding SELinux relabeling (`:Z`) for bind mounts.
- Adding `:U` to the Node-RED `/data` volume so the container user can seed `flows.json`.
- Giving the Podman data volume a stable name for easier cleanup.
- Adding an explicit `mosquitto` network alias so Node-RED can resolve `mqtt://mosquitto:1883`.
- Documenting cleanup and diagnostics for Podman Compose permission and DNS issues.

Docker Compose remains unchanged and continues to use `docker-compose.yaml`.

**Validation**
- `node samples/node/node-red-gateway/tests/validate-sample.mjs`
- `docker-compose -f samples/node/node-red-gateway/docker-compose.yaml config --quiet`
- `docker-compose -f samples/node/node-red-gateway/podman-compose.yaml config --quiet`
- `git verify-commit HEAD`