### PR TITLE
feat(archive-domain): add archive-domain sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@
 # Config files
 environ.sh
 config.py
+!samples/python/archive-domain/archive_domain/config.py
 iot_config.yaml
 data_access.json
+samples/python/archive-domain/data/archive_config.yaml
 
 # Certificates
 *.pem

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ as well as the messages received.
 | Sending observed time in device payload              | [Sample](./samples/script/time-observed/) |              | [Sample](./samples/C/M5Stack/) |              |
 | Raw command-response scenario                        |                       | [Sample](./samples/python/command-response/)  | [Sample](./samples/C/M5Stack/) |              |
 | Direct database connection — query telemetry         | [Sample](./samples/script/query-db/) | [Sample](./samples/python/query-db/)  |              | [Sample](./samples/java/src/main/java/com/oracle/iot/samples/SampleDataAccess.java) |
+| Archive IoT Domain data to Object Storage            | [Sample](./samples/sql/archive-domain/) | [Sample](./samples/python/archive-domain/) |              |              |
 | Streaming IoT Platform data (Database queues)        |                       | [Sample](./samples/python/queues/)  |              | [Sample](./samples/java/src/main/java/com/oracle/iot/samples/SampleDataStreaming.java) |
 
 ## End-to-End Samples
@@ -77,6 +78,10 @@ as well as the messages received.
   a device can request an upload over MQTT, have a backend agent consume IoT
   Platform database queue messages, create short-lived Object Storage upload
   URLs, send responses through raw commands, and run optional post-processing.
+- The Archive IoT Domain data samples show how to plan and archive retained IoT
+  Platform data to Object Storage using either
+  [`SQL`](./samples/sql/archive-domain/) or
+  [`Python`](./samples/python/archive-domain/).
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ select = ["C4", "D", "E", "F", "I", "N", "W"]
 ignore = ["D100", "D103", "D212", "E203", "E402", "E501"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["manage_dt"]
+known-first-party = ["archive_domain", "manage_dt"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/samples/python/archive-domain/README.md
+++ b/samples/python/archive-domain/README.md
@@ -1,0 +1,87 @@
+# Archive IoT Domain Data To Object Storage
+
+Sample Python application to plan and run whole-domain archival for OCI IoT
+Domain data.
+
+For shared archive-domain background, including the plan/run workflow,
+datasets, retention-based archive windows, Object Storage layout, and bucket
+access guidance, see [Shared Concepts](../../sql/archive-domain/README.md#shared-concepts)
+in the SQL sample README. This README focuses on Python-specific install,
+configuration, and execution details.
+
+The CLI currently exposes two commands:
+
+- `archive-domain plan`
+- `archive-domain run`
+
+The Python implementation supports the same three datasets:
+
+- `raw`
+- `historized`
+- `rejected`
+
+The sample supports two execution modes:
+
+- `bulk`: database-side export using `DBMS_CLOUD.EXPORT_DATA`; supports both
+  `parquet` and `datapump` based on the run-level `export_format`
+- `sql`: direct-query execution path used when you explicitly select it
+
+## Export Formats
+
+### Parquet
+
+For Parquet `raw` and `rejected` exports, the sample emits:
+
+- `content`
+- `content_type`
+- `content_encoding`
+- `content_representation`
+
+Consumers should use `content_encoding` and `content_representation` together
+with `content_type` to interpret `content` safely.
+
+Expected combinations are:
+
+- `content_encoding = json`, `content_representation = parsed-json`
+- `content_encoding = text`, `content_representation = json-string`
+- `content_encoding = base64`, `content_representation = base64-string`
+
+Malformed `application/json` payloads fall back to
+`base64` / `base64-string`.
+
+### Data Pump
+
+Set `export_format` to `datapump` when you want database-side Data Pump exports
+from the `bulk` execution path.
+
+Data Pump runs require selecting exactly one dataset. Use Parquet when you want
+one run to archive multiple datasets.
+
+## Install
+
+```sh
+python3 -m venv venv
+source venv/bin/activate
+python -m pip install --upgrade pip
+pip install .
+```
+
+## Configure
+
+From the repository root, copy
+`samples/python/archive-domain/data/archive_config.distr.yaml` to
+`samples/python/archive-domain/data/archive_config.yaml` and fill in your IoT
+Domain, direct database, and Object Storage values.
+
+Set `export_format` to either `parquet` or `datapump`. The distributed config
+defaults to `parquet`, uses `DOMAIN_ARCHIVE_TEST` as the placeholder
+`DBMS_CLOUD` credential name, and matches the CLI's default `--config` path.
+
+## Usage
+
+```sh
+archive-domain --help
+archive-domain plan --datasets raw,historized,rejected
+archive-domain run --datasets raw,historized --dry-run
+archive-domain run --datasets raw --mode bulk
+```

--- a/samples/python/archive-domain/archive_domain/__init__.py
+++ b/samples/python/archive-domain/archive_domain/__init__.py
@@ -1,0 +1,8 @@
+"""Archive-domain sample package.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""

--- a/samples/python/archive-domain/archive_domain/cli.py
+++ b/samples/python/archive-domain/archive_domain/cli.py
@@ -1,0 +1,179 @@
+"""CLI for the archive-domain sample.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import click
+
+from .service import build_service
+
+
+def _format_timestamp(value: datetime | None) -> str:
+    if value is None:
+        return "none"
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(_ctx: click.Context, _param: click.Parameter, value: str | None):
+    if value is None:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+@click.group()
+@click.option(
+    "--config",
+    "config_path",
+    default="samples/python/archive-domain/data/archive_config.yaml",
+    show_default=True,
+    help="Path to the archive-domain YAML config file.",
+)
+@click.option(
+    "--profile",
+    default=os.getenv("OCI_CLI_PROFILE", "DEFAULT"),
+    show_default=True,
+    help="OCI config profile name.",
+)
+@click.option(
+    "--auth",
+    type=click.Choice(
+        ["api_key", "instance_principal", "resource_principal", "security_token"]
+    ),
+    default=os.getenv("OCI_CLI_AUTH", "api_key"),
+    show_default=True,
+    help="OCI authentication type.",
+)
+@click.pass_context
+def cli(ctx: click.Context, config_path: str, profile: str, auth: str):
+    """Archive IoT Domain telemetry."""
+    ctx.ensure_object(dict)
+    ctx.obj["config_path"] = config_path
+    ctx.obj["profile"] = profile
+    ctx.obj["auth"] = auth
+
+
+@cli.command()
+@click.option(
+    "--datasets",
+    default="raw,historized,rejected",
+    show_default=True,
+    help="Comma-separated dataset list.",
+)
+@click.option(
+    "--start-time",
+    callback=_parse_timestamp,
+    help="Explicit archive window start in ISO-8601 format.",
+)
+@click.option(
+    "--end-time",
+    callback=_parse_timestamp,
+    help="Explicit archive window end in ISO-8601 format.",
+)
+@click.pass_context
+def plan(
+    ctx: click.Context,
+    datasets: str,
+    start_time: datetime | None,
+    end_time: datetime | None,
+):
+    """Plan archive work."""
+    service = build_service(
+        ctx.obj["config_path"], profile=ctx.obj["profile"], auth=ctx.obj["auth"]
+    )
+    plan_result = service.plan(
+        datasets=datasets, start_time=start_time, end_time=end_time
+    )
+
+    click.echo(
+        f"Checkpoint: {_format_timestamp(plan_result.checkpoint.last_successful_run_at)}"
+    )
+    for dataset in plan_result.plan.selected_datasets:
+        dataset_plan = plan_result.plan.datasets[dataset]
+        click.echo(
+            f"{dataset}: {_format_timestamp(dataset_plan.window_start)} -> "
+            f"{_format_timestamp(dataset_plan.window_end)} "
+            f"(retention={dataset_plan.retention_days}d)"
+        )
+
+
+@cli.command()
+@click.option(
+    "--datasets",
+    default="raw,historized,rejected",
+    show_default=True,
+    help="Comma-separated dataset list.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["bulk", "sql"]),
+    default="bulk",
+    show_default=True,
+    help="Preferred archive execution mode.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Plan and print pending archive actions without exporting data.",
+)
+@click.option(
+    "--start-time",
+    callback=_parse_timestamp,
+    help="Explicit archive window start in ISO-8601 format.",
+)
+@click.option(
+    "--end-time",
+    callback=_parse_timestamp,
+    help="Explicit archive window end in ISO-8601 format.",
+)
+@click.pass_context
+def run(
+    ctx: click.Context,
+    datasets: str,
+    mode: str,
+    dry_run: bool,
+    start_time: datetime | None,
+    end_time: datetime | None,
+):
+    """Run archive work."""
+    service = build_service(
+        ctx.obj["config_path"], profile=ctx.obj["profile"], auth=ctx.obj["auth"]
+    )
+    run_result = service.run(
+        datasets=datasets,
+        mode=mode,
+        dry_run=dry_run,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    click.echo(f"Run ID: {run_result.run_id}")
+    click.echo(f"Mode: {run_result.mode}")
+    if dry_run:
+        click.echo("Dry run only; no data exported.")
+    for dataset_result in run_result.dataset_results:
+        click.echo(
+            f"{dataset_result.name}: {dataset_result.status} "
+            f"({dataset_result.export_mode}, {dataset_result.export_format})"
+        )
+    click.echo(
+        f"Checkpoint advanced: {'yes' if run_result.checkpoint_advanced else 'no'}"
+    )
+    failed_results = [
+        result for result in run_result.dataset_results if result.status == "failed"
+    ]
+    if failed_results:
+        details = "; ".join(
+            f"{result.name}: {result.error_message or 'export failed'}"
+            for result in failed_results
+        )
+        raise click.ClickException(f"One or more dataset exports failed: {details}")

--- a/samples/python/archive-domain/archive_domain/config.py
+++ b/samples/python/archive-domain/archive_domain/config.py
@@ -1,0 +1,98 @@
+"""Configuration loading for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class IotConfig:
+    """IoT-specific configuration."""
+
+    domain_id: str
+    retention_days: dict[str, int | None]
+    bootstrap_lookback_days: int
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    """Direct database configuration."""
+
+    connect_string: str
+    token_scope: str
+    iot_domain_short_name: str
+    auth_type: str
+    profile: str
+    thick_mode: bool
+    lib_dir: str | None
+    dbms_cloud_credential_name: str | None
+
+
+@dataclass(frozen=True)
+class ObjectStorageConfig:
+    """Object Storage configuration."""
+
+    namespace: str | None
+    bucket_name: str
+    prefix: str
+    manifest_prefix: str
+    checkpoint_object: str
+
+
+@dataclass(frozen=True)
+class ArchiveConfig:
+    """Full archive-domain configuration."""
+
+    iot: IotConfig
+    database: DatabaseConfig
+    object_storage: ObjectStorageConfig
+    export_format: str = "parquet"
+
+
+def load_config(path: str | Path) -> ArchiveConfig:
+    """Load archive-domain YAML configuration."""
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as file_obj:
+        data = yaml.safe_load(file_obj) or {}
+
+    iot = data.get("iot", {})
+    database = data.get("database", {})
+    object_storage = data.get("object_storage", {})
+
+    return ArchiveConfig(
+        iot=IotConfig(
+            domain_id=iot["domain_id"],
+            retention_days=iot.get("retention_days", {}),
+            bootstrap_lookback_days=int(iot.get("bootstrap_lookback_days", 1)),
+        ),
+        database=DatabaseConfig(
+            connect_string=database["connect_string"],
+            token_scope=database["token_scope"],
+            iot_domain_short_name=database["iot_domain_short_name"],
+            auth_type=database.get("auth_type", "InstancePrincipal"),
+            profile=database.get("profile", "DEFAULT"),
+            thick_mode=bool(database.get("thick_mode", False)),
+            lib_dir=database.get("lib_dir"),
+            dbms_cloud_credential_name=database.get("dbms_cloud_credential_name"),
+        ),
+        object_storage=ObjectStorageConfig(
+            namespace=object_storage.get("namespace"),
+            bucket_name=object_storage["bucket_name"],
+            prefix=object_storage.get("prefix", "iot-archive"),
+            manifest_prefix=object_storage.get("manifest_prefix", "_manifests"),
+            checkpoint_object=object_storage.get(
+                "checkpoint_object", "_state/checkpoint.json"
+            ),
+        ),
+        export_format=str(data.get("export_format", "parquet")).lower(),
+    )

--- a/samples/python/archive-domain/archive_domain/db.py
+++ b/samples/python/archive-domain/archive_domain/db.py
@@ -1,0 +1,82 @@
+"""Direct database helpers for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def choose_execution_mode(
+    requested_mode: str,
+    dbms_cloud_available: bool,
+    has_db_export_credentials: bool,
+) -> str:
+    """Choose between bulk export and SQL fallback."""
+    if requested_mode == "sql":
+        return "sql"
+    if dbms_cloud_available and has_db_export_credentials:
+        return "bulk"
+    return "sql"
+
+
+def build_dsn(connect_string: str) -> str:
+    """Convert the IoT DB connect string into an Oracle DSN."""
+    match = re.match(r"tcps:(.*):(\d+)/([^?]*)(\?.*)?", connect_string)
+    if not match:
+        raise ValueError("Invalid connect string")
+
+    hostname, port, service, _ = match.groups()
+    return f"""
+        (DESCRIPTION =
+            (ADDRESS=(PROTOCOL=TCPS)(PORT={port})(HOST={hostname}))
+            (CONNECT_DATA=(SERVICE_NAME={service}))
+        )"""
+
+
+def connect(database_config: Any):
+    """Create a direct database connection using OCI token auth."""
+    try:
+        import oracledb
+        import oracledb.plugins.oci_tokens  # noqa: F401
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "python-oracledb with OCI token support is required for direct DB access"
+        ) from exc
+
+    extra_auth_params = {
+        "auth_type": database_config.auth_type,
+        "scope": database_config.token_scope,
+    }
+    if database_config.auth_type in {"ConfigFileAuthentication", "SecurityToken"}:
+        extra_auth_params["profile"] = database_config.profile
+
+    connect_kwargs: dict[str, Any] = {}
+    if database_config.thick_mode:
+        oracledb.init_oracle_client(lib_dir=database_config.lib_dir, config_dir=".")
+        connect_kwargs["externalauth"] = True
+
+    return oracledb.connect(
+        dsn=build_dsn(database_config.connect_string),
+        extra_auth_params=extra_auth_params,
+        **connect_kwargs,
+    )
+
+
+def set_current_schema(connection: Any, iot_domain_short_name: str) -> None:
+    """Switch the session to the IoT schema for the selected domain."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"alter session set current_schema = {iot_domain_short_name}__iot"
+        )
+
+
+def execute_statement(cursor: Any, statement: str, binds: dict[str, Any]) -> None:
+    """Execute one statement with bind values."""
+    cursor.execute(statement, binds)

--- a/samples/python/archive-domain/archive_domain/executor.py
+++ b/samples/python/archive-domain/archive_domain/executor.py
@@ -1,0 +1,172 @@
+"""Runtime executor for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+import base64
+import decimal
+import gzip
+import io
+import json
+from datetime import date, datetime, timezone
+from typing import Any
+
+from .db import choose_execution_mode, connect, execute_statement, set_current_schema
+from .exporters import build_bulk_export_request, export_format_for_dataset
+from .models import EXPORT_FORMAT_PARQUET, DatasetResult
+from .object_storage import build_dbms_cloud_file_uri, build_object_name
+from .sql import build_dataset_query
+
+
+def _normalize_value(value: Any) -> Any:
+    if hasattr(value, "read"):
+        value = value.read()
+
+    if isinstance(value, bytes):
+        return {
+            "encoding": "base64",
+            "data": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: _normalize_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(item) for item in value]
+    return value
+
+
+class LiveArchiveExecutor:
+    """Execute dataset archives using direct DB and Object Storage clients."""
+
+    def __init__(
+        self,
+        config,
+        object_storage_client: Any,
+        namespace: str,
+        region: str | None,
+    ):
+        """Store runtime dependencies for live archive execution."""
+        self.config = config
+        self.object_storage_client = object_storage_client
+        self.namespace = namespace
+        self.region = region
+
+    def execute_dataset(
+        self,
+        dataset,
+        dataset_plan,
+        mode,
+        object_prefix,
+        export_format,
+    ) -> DatasetResult:
+        """Execute archive export for one dataset."""
+        actual_mode = choose_execution_mode(
+            requested_mode=mode,
+            dbms_cloud_available=bool(
+                self.region and self.config.database.dbms_cloud_credential_name
+            ),
+            has_db_export_credentials=bool(
+                self.config.database.dbms_cloud_credential_name
+            ),
+        )
+        if actual_mode == "sql":
+            if export_format != EXPORT_FORMAT_PARQUET:
+                raise RuntimeError("sql mode supports only parquet exports")
+            return self._execute_sql(
+                dataset, dataset_plan, object_prefix, export_format
+            )
+        if actual_mode == "bulk":
+            return self._execute_bulk(
+                dataset, dataset_plan, object_prefix, export_format
+            )
+        return self._execute_sql(dataset, dataset_plan, object_prefix, export_format)
+
+    def _execute_bulk(
+        self, dataset, dataset_plan, object_prefix, export_format
+    ) -> DatasetResult:
+        file_uri_list = build_dbms_cloud_file_uri(
+            region=self.region,
+            namespace=self.namespace,
+            bucket_name=self.config.object_storage.bucket_name,
+            object_prefix=object_prefix,
+            basename=dataset,
+        )
+        dataset_query, statement, binds = build_bulk_export_request(
+            dataset=dataset,
+            window_start=dataset_plan.window_start,
+            window_end=dataset_plan.window_end,
+            credential_name=self.config.database.dbms_cloud_credential_name,
+            file_uri_list=file_uri_list,
+            domain_short_name=self.config.database.iot_domain_short_name,
+            export_format=export_format,
+        )
+
+        with connect(self.config.database) as connection:
+            set_current_schema(connection, self.config.database.iot_domain_short_name)
+            with connection.cursor() as cursor:
+                execute_statement(cursor, statement, binds)
+
+        return DatasetResult(
+            name=dataset,
+            status="succeeded",
+            export_mode="bulk",
+            export_format=export_format_for_dataset(dataset, export_format),
+            object_prefix=object_prefix,
+        )
+
+    def _execute_sql(
+        self, dataset, dataset_plan, object_prefix, export_format
+    ) -> DatasetResult:
+        dataset_query = build_dataset_query(
+            dataset,
+            dataset_plan.window_start,
+            dataset_plan.window_end,
+            domain_short_name=self.config.database.iot_domain_short_name,
+            export_format=export_format,
+        )
+
+        buffer = io.BytesIO()
+        with connect(self.config.database) as connection:
+            set_current_schema(connection, self.config.database.iot_domain_short_name)
+            with connection.cursor() as cursor:
+                cursor.execute(dataset_query.sql_text, dataset_query.binds)
+                columns = [column[0].lower() for column in cursor.description]
+
+                with gzip.GzipFile(fileobj=buffer, mode="wb") as gzip_file:
+                    for row in cursor:
+                        record = {
+                            column: _normalize_value(value)
+                            for column, value in zip(columns, row)
+                        }
+                        gzip_file.write(
+                            json.dumps(record, sort_keys=True).encode("utf-8")
+                        )
+                        gzip_file.write(b"\n")
+
+        object_name = build_object_name(object_prefix, "part-00000.jsonl.gz")
+        self.object_storage_client.put_object(
+            namespace_name=self.namespace,
+            bucket_name=self.config.object_storage.bucket_name,
+            object_name=object_name,
+            put_object_body=buffer.getvalue(),
+        )
+
+        return DatasetResult(
+            name=dataset,
+            status="succeeded",
+            export_mode="sql",
+            export_format=export_format,
+            object_prefix=object_prefix,
+            object_names=(object_name,),
+        )

--- a/samples/python/archive-domain/archive_domain/exporters.py
+++ b/samples/python/archive-domain/archive_domain/exporters.py
@@ -1,0 +1,55 @@
+"""Export strategy helpers for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from .models import VALID_EXPORT_FORMATS
+from .sql import DatasetQuery, build_dataset_query, build_dbms_cloud_export_statement
+
+
+def export_format_for_dataset(dataset: str, run_export_format: str = "parquet") -> str:
+    """Return the configured run format for a dataset."""
+    _ = dataset
+    export_format = run_export_format.lower()
+    if export_format not in VALID_EXPORT_FORMATS:
+        raise ValueError(f"Unsupported export format: {run_export_format}")
+    return export_format
+
+
+def dataset_zone(dataset: str) -> str:
+    """Return the archive zone for a dataset."""
+    if dataset in {"raw", "rejected"}:
+        return "bronze"
+    if dataset == "historized":
+        return "silver"
+    raise ValueError(f"Unsupported dataset: {dataset}")
+
+
+def build_bulk_export_request(
+    dataset: str,
+    window_start,
+    window_end,
+    credential_name: str,
+    file_uri_list: str,
+    domain_short_name: str,
+    export_format: str = "parquet",
+) -> tuple[DatasetQuery, str, dict]:
+    """Build the dataset query and DBMS_CLOUD export statement."""
+    dataset_query = build_dataset_query(
+        dataset,
+        window_start,
+        window_end,
+        domain_short_name=domain_short_name,
+        export_format=export_format,
+    )
+    statement, binds = build_dbms_cloud_export_statement(
+        dataset_query=dataset_query,
+        credential_name=credential_name,
+        file_uri_list=file_uri_list,
+        export_format=export_format_for_dataset(dataset, export_format),
+    )
+    return dataset_query, statement, binds

--- a/samples/python/archive-domain/archive_domain/iot_domain.py
+++ b/samples/python/archive-domain/archive_domain/iot_domain.py
@@ -1,0 +1,107 @@
+"""IoT Domain metadata helpers.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .models import VALID_DATASETS
+
+
+class IotDomainLookup:
+    """Thin wrapper around an IoT client."""
+
+    def __init__(self, client: Any, iot_domain_id: str):
+        """Capture the IoT client and target IoT Domain identifier."""
+        self.client = client
+        self.iot_domain_id = iot_domain_id
+
+    def get_retention_days(self) -> dict[str, int]:
+        """Fetch retention settings for the configured IoT Domain."""
+        response = self.client.get_iot_domain(iot_domain_id=self.iot_domain_id)
+        return extract_retention_days(response.data)
+
+
+def _read_value(source: Any, *keys: str) -> Any:
+    if source is None:
+        return None
+
+    if isinstance(source, Mapping):
+        for key in keys:
+            if key in source:
+                return source[key]
+            normalized_key = key.replace("-", "_")
+            if normalized_key in source:
+                return source[normalized_key]
+        return None
+
+    for key in keys:
+        if hasattr(source, key):
+            return getattr(source, key)
+        normalized_key = key.replace("-", "_")
+        if hasattr(source, normalized_key):
+            return getattr(source, normalized_key)
+    return None
+
+
+def extract_retention_days(domain: Any) -> dict[str, int]:
+    """Extract retention days from an IoT Domain response object or mapping."""
+    retention_source = _read_value(
+        domain,
+        "data-retention-periods-in-days",
+        "data_retention_periods_in_days",
+    )
+
+    if retention_source is None:
+        return {}
+
+    key_map = {
+        "raw": ("raw", "rawData", "raw_data", "raw-data"),
+        "historized": (
+            "historized",
+            "historizedData",
+            "historized_data",
+            "historized-data",
+        ),
+        "rejected": ("rejected", "rejectedData", "rejected_data", "rejected-data"),
+    }
+
+    resolved: dict[str, int] = {}
+    for dataset, keys in key_map.items():
+        value = _read_value(retention_source, *keys)
+        if value is not None:
+            resolved[dataset] = int(value)
+    return resolved
+
+
+def resolve_retention_days(
+    lookup_client: Any,
+    configured_overrides: dict[str, int | None],
+    required_datasets: tuple[str, ...] = VALID_DATASETS,
+) -> dict[str, int]:
+    """Resolve retention days from live lookup first, then configured overrides."""
+    resolved: dict[str, int] = {}
+
+    try:
+        resolved.update(lookup_client.get_retention_days())
+    except Exception:
+        pass
+
+    for dataset in required_datasets:
+        value = configured_overrides.get(dataset)
+        if value is not None:
+            resolved[dataset] = int(value)
+
+    missing = [dataset for dataset in required_datasets if dataset not in resolved]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise ValueError(f"Missing retention values for datasets: {missing_text}")
+
+    return resolved

--- a/samples/python/archive-domain/archive_domain/manifest.py
+++ b/samples/python/archive-domain/archive_domain/manifest.py
@@ -1,0 +1,45 @@
+"""Manifest helpers for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from typing import Any
+
+from .models import DatasetResult
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, datetime):
+        return value.isoformat().replace("+00:00", "Z")
+    if isinstance(value, dict):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def build_run_manifest(
+    run_id: str,
+    selected_datasets: tuple[str, ...],
+    retention_days: dict[str, int],
+    checkpoint_before: str | None,
+    dataset_results: list[DatasetResult],
+) -> dict[str, Any]:
+    """Build a minimal run manifest payload."""
+    return {
+        "run_id": run_id,
+        "selected_datasets": list(selected_datasets),
+        "retention_days": retention_days,
+        "checkpoint_before": checkpoint_before,
+        "dataset_results": [_to_jsonable(result) for result in dataset_results],
+    }

--- a/samples/python/archive-domain/archive_domain/models.py
+++ b/samples/python/archive-domain/archive_domain/models.py
@@ -1,0 +1,82 @@
+"""Domain models for the archive-domain sample.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+VALID_DATASETS = ("raw", "historized", "rejected")
+
+EXPORT_FORMAT_PARQUET = "parquet"
+EXPORT_FORMAT_DATAPUMP = "datapump"
+VALID_EXPORT_FORMATS = (EXPORT_FORMAT_PARQUET, EXPORT_FORMAT_DATAPUMP)
+
+
+@dataclass(frozen=True)
+class DatasetPlan:
+    """Archive plan details for one dataset."""
+
+    name: str
+    retention_days: int
+    purge_boundary: datetime
+    window_start: datetime
+    window_end: datetime
+
+
+@dataclass(frozen=True)
+class ArchivePlan:
+    """Archive plan for the selected datasets."""
+
+    now: datetime
+    selected_datasets: tuple[str, ...]
+    datasets: dict[str, DatasetPlan]
+
+
+@dataclass(frozen=True)
+class CheckpointState:
+    """Latest successful archive checkpoint."""
+
+    last_successful_run_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class DatasetResult:
+    """Outcome for one dataset in a run."""
+
+    name: str
+    status: str
+    export_mode: str | None = None
+    export_format: str | None = None
+    object_prefix: str | None = None
+    object_names: tuple[str, ...] = ()
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class PlanResult:
+    """Planned archive work plus supporting context."""
+
+    plan: ArchivePlan
+    export_format: str
+    retention_days: dict[str, int]
+    checkpoint: CheckpointState
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Result of one archive run."""
+
+    run_id: str
+    mode: str
+    export_format: str
+    plan_result: PlanResult
+    dataset_results: tuple[DatasetResult, ...]
+    checkpoint_advanced: bool
+    manifest_object_name: str | None = None

--- a/samples/python/archive-domain/archive_domain/object_storage.py
+++ b/samples/python/archive-domain/archive_domain/object_storage.py
@@ -1,0 +1,140 @@
+"""Object Storage state helpers for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from typing import Any
+from urllib.parse import quote
+
+from .models import CheckpointState
+
+
+def should_advance_checkpoint(statuses: dict[str, str]) -> bool:
+    """Advance the checkpoint only if all selected datasets succeeded."""
+    if not statuses:
+        return False
+    return all(status == "succeeded" for status in statuses.values())
+
+
+def build_dataset_object_prefix(
+    prefix: str,
+    domain_short_name: str,
+    zone: str,
+    dataset: str,
+    run_id: str,
+    run_at: datetime,
+) -> str:
+    """Build the partitioned object prefix for one dataset."""
+    normalized_prefix = prefix.strip("/")
+    return (
+        f"{normalized_prefix}/domain={domain_short_name}/zone={zone}/dataset={dataset}/"
+        f"year={run_at:%Y}/month={run_at:%m}/day={run_at:%d}/hour={run_at:%H}/"
+        f"run_id={run_id}"
+    )
+
+
+def build_manifest_object_name(manifest_prefix: str, run_id: str) -> str:
+    """Build the manifest object name for a run."""
+    return f"{manifest_prefix.strip('/')}/run_id={run_id}.json"
+
+
+def build_object_name(object_prefix: str, filename: str) -> str:
+    """Build one object name beneath a dataset object prefix."""
+    return f"{object_prefix.strip('/')}/{filename}"
+
+
+def build_dbms_cloud_file_uri(
+    region: str,
+    namespace: str,
+    bucket_name: str,
+    object_prefix: str,
+    basename: str = "part",
+) -> str:
+    """Build the Object Storage URI used by DBMS_CLOUD.EXPORT_DATA."""
+    encoded_prefix = quote(object_prefix.strip("/"), safe="/=")
+    encoded_basename = quote(basename, safe="-.")
+    return (
+        f"https://objectstorage.{region}.oraclecloud.com/n/{namespace}/"
+        f"b/{bucket_name}/o/{encoded_prefix}/{encoded_basename}"
+    )
+
+
+def _serialize(payload: Any) -> bytes:
+    if is_dataclass(payload):
+        payload = asdict(payload)
+    return json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+class ObjectStorageStateStore:
+    """Thin JSON-oriented wrapper around Object Storage operations."""
+
+    def __init__(self, client: Any, namespace: str, bucket_name: str):
+        """Store the Object Storage client and target bucket details."""
+        self.client = client
+        self.namespace = namespace
+        self.bucket_name = bucket_name
+
+    def get_json_object(self, object_name: str) -> dict[str, Any] | None:
+        """Read one JSON object from Object Storage."""
+        try:
+            response = self.client.get_object(
+                namespace_name=self.namespace,
+                bucket_name=self.bucket_name,
+                object_name=object_name,
+            )
+        except Exception as exc:
+            status = getattr(exc, "status", None)
+            code = getattr(exc, "code", None)
+            if status == 404 or code == "ObjectNotFound":
+                return None
+            raise
+
+        return json.loads(response.data.content.decode("utf-8"))
+
+    def put_json_object(self, object_name: str, payload: Any) -> None:
+        """Write one JSON object to Object Storage."""
+        self.client.put_object(
+            namespace_name=self.namespace,
+            bucket_name=self.bucket_name,
+            object_name=object_name,
+            put_object_body=_serialize(payload),
+        )
+
+    def load_checkpoint(self, object_name: str) -> CheckpointState:
+        """Load the current checkpoint or return an empty one."""
+        payload = self.get_json_object(object_name)
+        if payload is None:
+            return CheckpointState()
+
+        return CheckpointState(
+            last_successful_run_at=_parse_timestamp(
+                payload.get("last_successful_run_at")
+            )
+        )
+
+    def save_checkpoint(self, object_name: str, checkpoint: CheckpointState) -> None:
+        """Persist checkpoint state."""
+        payload = {
+            "last_successful_run_at": (
+                checkpoint.last_successful_run_at.isoformat().replace("+00:00", "Z")
+                if checkpoint.last_successful_run_at is not None
+                else None
+            )
+        }
+        self.put_json_object(object_name, payload)

--- a/samples/python/archive-domain/archive_domain/oci_utils.py
+++ b/samples/python/archive-domain/archive_domain/oci_utils.py
@@ -1,0 +1,101 @@
+"""OCI client helpers for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def get_oci_config(
+    profile: str = os.getenv("OCI_CLI_PROFILE", "DEFAULT"),
+    auth: str = os.getenv("OCI_CLI_AUTH", "api_key"),
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load OCI config and signer details for the chosen auth mode."""
+    try:
+        from oci import config as oci_config
+        from oci import signer as oci_signer
+        from oci.auth import signers as oci_auth_signers
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The oci package is required for live OCI operations"
+        ) from exc
+
+    if auth == "api_key":
+        if os.getenv("OCI_CLI_KEY_CONTENT"):
+            signer = {}
+            config = {
+                "user": os.getenv("OCI_CLI_USER"),
+                "key_content": os.getenv("OCI_CLI_KEY_CONTENT"),
+                "fingerprint": os.getenv("OCI_CLI_FINGERPRINT"),
+                "tenancy": os.getenv("OCI_CLI_TENANCY"),
+                "region": os.getenv("OCI_CLI_REGION"),
+            }
+            oci_config.validate_config(config)
+        else:
+            signer = {}
+            config = oci_config.from_file(profile_name=profile)
+    elif auth == "instance_principal":
+        signer = {
+            "signer": oci_auth_signers.InstancePrincipalsSecurityTokenSigner(),
+        }
+        config = (
+            {"region": os.getenv("OCI_CLI_REGION")}
+            if os.getenv("OCI_CLI_REGION")
+            else {}
+        )
+    elif auth == "resource_principal":
+        signer = {
+            "signer": oci_auth_signers.get_resource_principals_signer(),
+        }
+        config = (
+            {"region": os.getenv("OCI_CLI_REGION")}
+            if os.getenv("OCI_CLI_REGION")
+            else {}
+        )
+    elif auth == "security_token":
+        config = oci_config.from_file(profile_name=profile)
+        with open(config["security_token_file"], "r", encoding="utf-8") as token_file:
+            token = token_file.read()
+        private_key = oci_signer.load_private_key_from_file(config["key_file"])
+        signer = {
+            "signer": oci_auth_signers.SecurityTokenSigner(token, private_key),
+        }
+    else:
+        raise ValueError(f"unsupported auth scheme {auth}")
+    return config, signer
+
+
+def resolve_region(config: dict[str, Any]) -> str | None:
+    """Resolve the OCI region from config or environment."""
+    return (
+        config.get("region") or os.getenv("OCI_CLI_REGION") or os.getenv("OCI_REGION")
+    )
+
+
+def build_iot_client(config: dict[str, Any], signer: dict[str, Any]):
+    """Create an OCI IoT client."""
+    try:
+        from oci import iot as oci_iot
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The oci package is required for live IoT operations"
+        ) from exc
+    return oci_iot.IotClient(config, **signer)
+
+
+def build_object_storage_client(config: dict[str, Any], signer: dict[str, Any]):
+    """Create an OCI Object Storage client."""
+    try:
+        from oci import object_storage
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The oci package is required for live Object Storage operations"
+        ) from exc
+    return object_storage.ObjectStorageClient(config, **signer)

--- a/samples/python/archive-domain/archive_domain/planner.py
+++ b/samples/python/archive-domain/archive_domain/planner.py
@@ -1,0 +1,72 @@
+"""Archive planning helpers.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from .models import VALID_DATASETS, ArchivePlan, DatasetPlan
+
+
+def parse_datasets(value: str | None) -> tuple[str, ...]:
+    """Normalize a comma-separated dataset selection."""
+    if not value:
+        return VALID_DATASETS
+
+    selected = {item.strip().lower() for item in value.split(",") if item.strip()}
+    if not selected:
+        raise ValueError("Dataset list cannot be empty")
+    unknown = sorted(selected.difference(VALID_DATASETS))
+    if unknown:
+        raise ValueError(f"Unknown datasets: {', '.join(unknown)}")
+
+    return tuple(dataset for dataset in VALID_DATASETS if dataset in selected)
+
+
+def build_archive_plan(
+    selected_datasets: list[str] | tuple[str, ...],
+    retention_days: dict[str, int],
+    now: datetime,
+    last_successful_run_at: datetime | None = None,
+    bootstrap_lookback_days: int | None = None,
+    explicit_start_time: datetime | None = None,
+    explicit_end_time: datetime | None = None,
+) -> ArchivePlan:
+    """Build a retention-aware archive plan for the selected datasets."""
+    datasets: dict[str, DatasetPlan] = {}
+
+    for dataset in selected_datasets:
+        retention = retention_days[dataset]
+        purge_boundary = now - timedelta(days=retention)
+        window_end = explicit_end_time or purge_boundary
+
+        if explicit_start_time is not None:
+            window_start = explicit_start_time
+        elif last_successful_run_at is not None:
+            window_start = last_successful_run_at - timedelta(days=retention)
+        elif bootstrap_lookback_days is not None:
+            window_start = purge_boundary - timedelta(days=bootstrap_lookback_days)
+        else:
+            raise ValueError(
+                "A checkpoint, explicit start time, or bootstrap lookback is required"
+            )
+
+        datasets[dataset] = DatasetPlan(
+            name=dataset,
+            retention_days=retention,
+            purge_boundary=purge_boundary,
+            window_start=window_start,
+            window_end=window_end,
+        )
+
+    return ArchivePlan(
+        now=now,
+        selected_datasets=tuple(selected_datasets),
+        datasets=datasets,
+    )

--- a/samples/python/archive-domain/archive_domain/service.py
+++ b/samples/python/archive-domain/archive_domain/service.py
@@ -1,0 +1,261 @@
+"""Service layer for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from .config import load_config
+from .executor import LiveArchiveExecutor
+from .exporters import dataset_zone
+from .iot_domain import IotDomainLookup, resolve_retention_days
+from .manifest import build_run_manifest
+from .models import (
+    EXPORT_FORMAT_DATAPUMP,
+    VALID_EXPORT_FORMATS,
+    CheckpointState,
+    DatasetResult,
+    PlanResult,
+    RunResult,
+)
+from .object_storage import (
+    ObjectStorageStateStore,
+    build_dataset_object_prefix,
+    build_manifest_object_name,
+    should_advance_checkpoint,
+)
+from .oci_utils import (
+    build_iot_client,
+    build_object_storage_client,
+    get_oci_config,
+    resolve_region,
+)
+from .planner import build_archive_plan, parse_datasets
+
+
+class NullRetentionLookup:
+    """Fallback retention lookup that returns no live values."""
+
+    def get_retention_days(self) -> dict[str, int]:
+        """Return no live retention values."""
+        return {}
+
+
+class ArchiveService:
+    """High-level archive planning and execution orchestration."""
+
+    def __init__(
+        self,
+        config,
+        retention_lookup: Any | None = None,
+        state_store: Any | None = None,
+        executor: Any | None = None,
+        clock: Any | None = None,
+    ):
+        """Store configuration and runtime collaborators for archive work."""
+        self.config = config
+        self.retention_lookup = retention_lookup or NullRetentionLookup()
+        self.state_store = state_store
+        self.executor = executor
+        self.clock = clock or (
+            lambda: datetime.now(timezone.utc).replace(microsecond=0)
+        )
+
+    def _load_checkpoint(self) -> CheckpointState:
+        if self.state_store is None:
+            return CheckpointState()
+        return self.state_store.load_checkpoint(
+            self.config.object_storage.checkpoint_object
+        )
+
+    def _validate_export_format(self, selected_datasets: tuple[str, ...]) -> None:
+        export_format = (self.config.export_format or "parquet").lower()
+
+        if export_format not in VALID_EXPORT_FORMATS:
+            raise ValueError(f"unsupported export_format: {export_format}")
+
+        if export_format == EXPORT_FORMAT_DATAPUMP:
+            if len(selected_datasets) != 1:
+                raise ValueError(
+                    "datapump export format requires selecting exactly one dataset"
+                )
+
+    def _resolved_export_format(self) -> str:
+        return (self.config.export_format or "parquet").lower()
+
+    def plan(
+        self,
+        datasets: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> PlanResult:
+        """Compute the archive plan for the selected datasets."""
+        selected_datasets = parse_datasets(datasets)
+        self._validate_export_format(selected_datasets)
+        export_format = self._resolved_export_format()
+        checkpoint = self._load_checkpoint()
+        retention_days = resolve_retention_days(
+            lookup_client=self.retention_lookup,
+            configured_overrides=self.config.iot.retention_days,
+            required_datasets=selected_datasets,
+        )
+        plan = build_archive_plan(
+            selected_datasets=list(selected_datasets),
+            retention_days=retention_days,
+            now=self.clock(),
+            last_successful_run_at=checkpoint.last_successful_run_at,
+            bootstrap_lookback_days=self.config.iot.bootstrap_lookback_days,
+            explicit_start_time=start_time,
+            explicit_end_time=end_time,
+        )
+        return PlanResult(
+            plan=plan,
+            export_format=export_format,
+            retention_days=retention_days,
+            checkpoint=checkpoint,
+        )
+
+    def run(
+        self,
+        datasets: str | None = None,
+        mode: str = "bulk",
+        dry_run: bool = False,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> RunResult:
+        """Run or simulate the archive flow."""
+        plan_result = self.plan(
+            datasets=datasets, start_time=start_time, end_time=end_time
+        )
+        run_at = plan_result.plan.now
+        run_id = run_at.strftime("%Y%m%dT%H%M%SZ")
+        dataset_results = []
+
+        for dataset in plan_result.plan.selected_datasets:
+            object_prefix = build_dataset_object_prefix(
+                prefix=self.config.object_storage.prefix,
+                domain_short_name=self.config.database.iot_domain_short_name,
+                zone=dataset_zone(dataset),
+                dataset=dataset,
+                run_id=run_id,
+                run_at=run_at,
+            )
+
+            if dry_run:
+                dataset_results.append(
+                    DatasetResult(
+                        name=dataset,
+                        status="planned",
+                        export_mode=mode,
+                        export_format=plan_result.export_format,
+                        object_prefix=object_prefix,
+                    )
+                )
+                continue
+
+            if self.executor is None:
+                raise RuntimeError(
+                    "No archive executor is configured. Use --dry-run or provide a runtime executor."
+                )
+
+            try:
+                dataset_results.append(
+                    self.executor.execute_dataset(
+                        dataset=dataset,
+                        dataset_plan=plan_result.plan.datasets[dataset],
+                        mode=mode,
+                        object_prefix=object_prefix,
+                        export_format=plan_result.export_format,
+                    )
+                )
+            except Exception as exc:
+                dataset_results.append(
+                    DatasetResult(
+                        name=dataset,
+                        status="failed",
+                        export_mode=mode,
+                        export_format=plan_result.export_format,
+                        object_prefix=object_prefix,
+                        error_message=str(exc),
+                    )
+                )
+
+        manifest_object_name = build_manifest_object_name(
+            self.config.object_storage.manifest_prefix, run_id
+        )
+        manifest = build_run_manifest(
+            run_id=run_id,
+            selected_datasets=plan_result.plan.selected_datasets,
+            retention_days=plan_result.retention_days,
+            checkpoint_before=(
+                plan_result.checkpoint.last_successful_run_at.isoformat().replace(
+                    "+00:00", "Z"
+                )
+                if plan_result.checkpoint.last_successful_run_at is not None
+                else None
+            ),
+            dataset_results=list(dataset_results),
+        )
+
+        checkpoint_advanced = False
+        if not dry_run:
+            statuses = {result.name: result.status for result in dataset_results}
+            checkpoint_advanced = should_advance_checkpoint(statuses)
+            if self.state_store is not None:
+                self.state_store.put_json_object(manifest_object_name, manifest)
+                if checkpoint_advanced:
+                    self.state_store.save_checkpoint(
+                        self.config.object_storage.checkpoint_object,
+                        CheckpointState(last_successful_run_at=run_at),
+                    )
+
+        return RunResult(
+            run_id=run_id,
+            mode=mode,
+            export_format=plan_result.export_format,
+            plan_result=plan_result,
+            dataset_results=tuple(dataset_results),
+            checkpoint_advanced=checkpoint_advanced,
+            manifest_object_name=manifest_object_name,
+        )
+
+
+def build_service(
+    config_path: str, profile: str | None = None, auth: str | None = None
+):
+    """Build the archive service from configuration."""
+    config = load_config(config_path)
+    oci_config, signer = get_oci_config(
+        profile=profile or "DEFAULT", auth=auth or "api_key"
+    )
+    iot_client = build_iot_client(oci_config, signer)
+    object_storage_client = build_object_storage_client(oci_config, signer)
+
+    namespace = config.object_storage.namespace
+    if namespace is None:
+        namespace = object_storage_client.get_namespace().data
+
+    state_store = ObjectStorageStateStore(
+        client=object_storage_client,
+        namespace=namespace,
+        bucket_name=config.object_storage.bucket_name,
+    )
+    executor = LiveArchiveExecutor(
+        config=config,
+        object_storage_client=object_storage_client,
+        namespace=namespace,
+        region=resolve_region(oci_config),
+    )
+    return ArchiveService(
+        config=config,
+        retention_lookup=IotDomainLookup(iot_client, config.iot.domain_id),
+        state_store=state_store,
+        executor=executor,
+    )

--- a/samples/python/archive-domain/archive_domain/sql.py
+++ b/samples/python/archive-domain/archive_domain/sql.py
@@ -1,0 +1,238 @@
+"""SQL builders for archive-domain.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from .models import EXPORT_FORMAT_DATAPUMP, EXPORT_FORMAT_PARQUET, VALID_EXPORT_FORMATS
+
+
+@dataclass(frozen=True)
+class DatasetQuery:
+    """A query and its bind values."""
+
+    dataset: str
+    sql_text: str
+    binds: dict[str, datetime]
+    time_column: str
+
+
+def dataset_time_column(dataset: str) -> str:
+    """Return the purge-relevant time column for a dataset."""
+    if dataset == "historized":
+        return "time_observed"
+    return "time_received"
+
+
+def _normalized_content_type_sql() -> str:
+    return "lower(trim(regexp_substr(content_type, '^[^;]+')))"
+
+
+def _json_candidate_sql() -> str:
+    return "to_clob(utl_raw.cast_to_varchar2(dbms_lob.substr(content, 32767, 1)))"
+
+
+def _content_encoding_sql() -> str:
+    content_type_expr = _normalized_content_type_sql()
+    json_candidate_expr = _json_candidate_sql()
+    return (
+        "case "
+        f"when {content_type_expr} like 'text/%' then 'text' "
+        f"when {content_type_expr} is null or instr({content_type_expr}, 'json') > 0 then "
+        f"  case when {json_candidate_expr} is json strict then 'json' else 'base64' end "
+        "else 'base64' "
+        "end"
+    )
+
+
+def _content_representation_sql() -> str:
+    content_type_expr = _normalized_content_type_sql()
+    json_candidate_expr = _json_candidate_sql()
+    return (
+        "case "
+        f"when {content_type_expr} like 'text/%' then 'json-string' "
+        f"when {content_type_expr} is null or instr({content_type_expr}, 'json') > 0 then "
+        f"  case when {json_candidate_expr} is json strict then 'parsed-json' else 'base64-string' end "
+        "else 'base64-string' "
+        "end"
+    )
+
+
+def build_dataset_query(
+    dataset: str,
+    window_start: datetime,
+    window_end: datetime,
+    domain_short_name: str | None = None,
+    export_format: str = EXPORT_FORMAT_PARQUET,
+) -> DatasetQuery:
+    """Build the dataset-specific SQL query."""
+    normalized_export_format = export_format.lower()
+    if normalized_export_format not in VALID_EXPORT_FORMATS:
+        raise ValueError(f"Unsupported export format: {export_format}")
+
+    if dataset == "raw" and normalized_export_format == EXPORT_FORMAT_PARQUET:
+        content_encoding_expr = _content_encoding_sql()
+        content_representation_expr = _content_representation_sql()
+        blob_to_json_expr = _blob_to_json_expr()
+        sql_text = """
+            select
+                id,
+                digital_twin_instance_id,
+                endpoint,
+                time_received,
+                content_type,
+                {content_encoding_expr} as content_encoding,
+                {content_representation_expr} as content_representation,
+                {blob_to_json_expr} as content
+            from raw_data
+            where time_received >= :window_start
+              and time_received < :window_end
+            order by time_received, id
+        """.strip().format(
+            content_encoding_expr=content_encoding_expr,
+            content_representation_expr=content_representation_expr,
+            blob_to_json_expr=blob_to_json_expr,
+        )
+        time_column = "time_received"
+    elif dataset == "raw" and normalized_export_format == EXPORT_FORMAT_DATAPUMP:
+        sql_text = """
+            select *
+            from raw_data
+            where time_received >= :window_start
+              and time_received < :window_end
+            order by time_received, id
+        """.strip()
+        time_column = "time_received"
+    elif dataset == "historized" and normalized_export_format == EXPORT_FORMAT_PARQUET:
+        sql_text = """
+            select
+                id,
+                digital_twin_instance_id,
+                content_path,
+                time_observed,
+                json_serialize(value returning varchar2(32767)) as value_json,
+                json_value(value, '$' returning number null on error) as value_number,
+                json_value(value, '$' returning varchar2(32767) null on error) as value_text
+            from historized_data
+            where time_observed >= :window_start
+              and time_observed < :window_end
+            order by time_observed, id
+        """.strip()
+        time_column = "time_observed"
+    elif dataset == "historized" and normalized_export_format == EXPORT_FORMAT_DATAPUMP:
+        sql_text = """
+            select *
+            from historized_data
+            where time_observed >= :window_start
+              and time_observed < :window_end
+            order by time_observed, id
+        """.strip()
+        time_column = "time_observed"
+    elif dataset == "rejected" and normalized_export_format == EXPORT_FORMAT_PARQUET:
+        content_encoding_expr = _content_encoding_sql()
+        content_representation_expr = _content_representation_sql()
+        blob_to_json_expr = _blob_to_json_expr()
+        sql_text = """
+            select
+                id,
+                digital_twin_instance_id,
+                endpoint,
+                time_received,
+                reason_code,
+                reason_message,
+                content_type,
+                {content_encoding_expr} as content_encoding,
+                {content_representation_expr} as content_representation,
+                {blob_to_json_expr} as content
+            from rejected_data
+            where time_received >= :window_start
+              and time_received < :window_end
+            order by time_received, id
+        """.strip().format(
+            content_encoding_expr=content_encoding_expr,
+            content_representation_expr=content_representation_expr,
+            blob_to_json_expr=blob_to_json_expr,
+        )
+        time_column = "time_received"
+    elif dataset == "rejected" and normalized_export_format == EXPORT_FORMAT_DATAPUMP:
+        sql_text = """
+            select *
+            from rejected_data
+            where time_received >= :window_start
+              and time_received < :window_end
+            order by time_received, id
+        """.strip()
+        time_column = "time_received"
+    else:
+        raise ValueError(
+            f"Unsupported dataset/export_format combination: {dataset}/{export_format}"
+        )
+
+    return DatasetQuery(
+        dataset=dataset,
+        sql_text=sql_text,
+        binds={"window_start": window_start, "window_end": window_end},
+        time_column=time_column,
+    )
+
+
+def _blob_to_json_expr() -> str:
+    return "blob_to_json(content, content_type)"
+
+
+def build_dbms_cloud_export_statement(
+    dataset_query: DatasetQuery,
+    credential_name: str,
+    file_uri_list: str,
+    export_format: str,
+) -> tuple[str, dict[str, str | datetime]]:
+    """Build the PL/SQL block for DBMS_CLOUD.EXPORT_DATA."""
+    statement = """
+        begin
+          dbms_cloud.export_data(
+            credential_name => :credential_name,
+            file_uri_list   => :file_uri_list,
+            format          => json_object('type' value :export_format),
+            query           => :query_text
+          );
+        end;
+    """.strip()
+    binds: dict[str, str | datetime] = {
+        "credential_name": credential_name,
+        "file_uri_list": file_uri_list,
+        "export_format": export_format,
+        "query_text": _render_dbms_cloud_query_text(dataset_query),
+    }
+    return statement, binds
+
+
+def _render_dbms_cloud_query_text(dataset_query: DatasetQuery) -> str:
+    """Inline timestamp literals because DBMS_CLOUD receives the query as a string."""
+    query_text = dataset_query.sql_text
+    for bind_name, bind_value in dataset_query.binds.items():
+        query_text = query_text.replace(
+            f":{bind_name}", _oracle_timestamp_tz_literal(bind_value)
+        )
+    return query_text
+
+
+def _oracle_timestamp_tz_literal(value: datetime) -> str:
+    """Render a timezone-aware datetime as an Oracle TIMESTAMP WITH TIME ZONE literal."""
+    if value.tzinfo is None:
+        raise ValueError("Timezone-aware timestamps are required for archive queries")
+
+    normalized = value.astimezone(timezone.utc).isoformat(timespec="microseconds")
+    return (
+        "to_timestamp_tz("
+        f"'{normalized}', "
+        "'YYYY-MM-DD\"T\"HH24:MI:SS.FF6TZH:TZM'"
+        ")"
+    )

--- a/samples/python/archive-domain/data/archive_config.distr.yaml
+++ b/samples/python/archive-domain/data/archive_config.distr.yaml
@@ -1,0 +1,28 @@
+# Archive-domain sample configuration.
+
+export_format: parquet
+
+iot:
+  domain_id: <IoT Domain OCID>
+  retention_days:
+    raw: null
+    historized: null
+    rejected: null
+  bootstrap_lookback_days: 1
+
+database:
+  connect_string: "tcps:adb.<region>.oraclecloud.com:1521/<redacted>"
+  token_scope: "urn:oracle:db::id::<Compartment OCID>"
+  iot_domain_short_name: <Domain Short Name>
+  auth_type: InstancePrincipal
+  profile: DEFAULT
+  thick_mode: false
+  lib_dir: null
+  dbms_cloud_credential_name: DOMAIN_ARCHIVE_TEST
+
+object_storage:
+  namespace: null
+  bucket_name: <Bucket Name>
+  prefix: iot-archive
+  manifest_prefix: _manifests
+  checkpoint_object: _state/checkpoint.json

--- a/samples/python/archive-domain/pyproject.toml
+++ b/samples/python/archive-domain/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "archive_domain"
+version = "0.0.1"
+description = "Archive OCI IoT Domain telemetry to Object Storage"
+readme = "README.md"
+requires-python = ">=3.12"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Libraries",
+  "Programming Language :: Python :: 3",
+  "Operating System :: POSIX :: Linux",
+]
+dependencies = [
+  "click~=8.2.0",
+  "oci~=2.0,>=2.161",
+  "oracledb~=3.0",
+  "PyYAML~=6.0.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "black==26.3.1",
+  "pytest>=9.0",
+  "ruff==0.15.8",
+]
+
+[project.scripts]
+archive-domain = "archive_domain.cli:cli"
+
+[tool.setuptools.packages.find]
+include = ["archive_domain*"]

--- a/samples/python/archive-domain/tests/conftest.py
+++ b/samples/python/archive-domain/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Test helpers for archive-domain."""
+
+import sys
+from pathlib import Path
+
+SAMPLE_ROOT = Path(__file__).resolve().parents[1]
+
+if str(SAMPLE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SAMPLE_ROOT))

--- a/samples/python/archive-domain/tests/test_cli_plan_run.py
+++ b/samples/python/archive-domain/tests/test_cli_plan_run.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timezone
+
+from click.testing import CliRunner
+
+from archive_domain.cli import cli
+from archive_domain.models import (
+    ArchivePlan,
+    CheckpointState,
+    DatasetPlan,
+    DatasetResult,
+    PlanResult,
+    RunResult,
+)
+
+
+class _FakeService:
+    def __init__(self, dataset_statuses=("planned", "planned")):
+        now = datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc)
+        datasets = {
+            "raw": DatasetPlan(
+                name="raw",
+                retention_days=16,
+                purge_boundary=datetime(2026, 3, 23, 12, 0, tzinfo=timezone.utc),
+                window_start=datetime(2026, 3, 22, 12, 0, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 23, 12, 0, tzinfo=timezone.utc),
+            ),
+            "historized": DatasetPlan(
+                name="historized",
+                retention_days=30,
+                purge_boundary=datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc),
+                window_start=datetime(2026, 3, 8, 12, 0, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 9, 12, 0, tzinfo=timezone.utc),
+            ),
+        }
+        self.plan_result = PlanResult(
+            plan=ArchivePlan(
+                now=now,
+                selected_datasets=("raw", "historized"),
+                datasets=datasets,
+            ),
+            export_format="parquet",
+            retention_days={"raw": 16, "historized": 30},
+            checkpoint=CheckpointState(
+                last_successful_run_at=datetime(2026, 4, 7, 12, 0, tzinfo=timezone.utc)
+            ),
+        )
+        self.run_result = RunResult(
+            run_id="run-123",
+            mode="bulk",
+            export_format="parquet",
+            plan_result=self.plan_result,
+            dataset_results=(
+                DatasetResult(
+                    name="raw",
+                    status=dataset_statuses[0],
+                    export_mode="bulk",
+                    export_format="datapump",
+                    error_message=(
+                        "simulated export failure"
+                        if dataset_statuses[0] == "failed"
+                        else None
+                    ),
+                ),
+                DatasetResult(
+                    name="historized",
+                    status=dataset_statuses[1],
+                    export_mode="bulk",
+                    export_format="parquet",
+                ),
+            ),
+            checkpoint_advanced=False,
+        )
+
+    def plan(self, **_kwargs):
+        return self.plan_result
+
+    def run(self, **_kwargs):
+        return self.run_result
+
+
+def test_plan_command_prints_selected_dataset_windows(monkeypatch):
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        "archive_domain.cli.build_service", lambda *_args, **_kwargs: _FakeService()
+    )
+
+    result = runner.invoke(cli, ["plan", "--datasets", "raw,historized"])
+
+    assert result.exit_code == 0
+    assert "raw" in result.output
+    assert "historized" in result.output
+    assert "2026-03-22T12:00:00Z" in result.output
+
+
+def test_run_dry_run_does_not_advance_checkpoint(monkeypatch):
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        "archive_domain.cli.build_service", lambda *_args, **_kwargs: _FakeService()
+    )
+
+    result = runner.invoke(cli, ["run", "--datasets", "raw,historized", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Checkpoint advanced: no" in result.output
+    assert "raw: planned" in result.output
+
+
+def test_run_command_exits_nonzero_when_any_dataset_fails(monkeypatch):
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        "archive_domain.cli.build_service",
+        lambda *_args, **_kwargs: _FakeService(
+            dataset_statuses=("failed", "succeeded")
+        ),
+    )
+
+    result = runner.invoke(cli, ["run", "--datasets", "raw,historized"])
+
+    assert result.exit_code != 0
+    assert "raw: failed" in result.output
+    assert "simulated export failure" in result.output

--- a/samples/python/archive-domain/tests/test_cli_smoke.py
+++ b/samples/python/archive-domain/tests/test_cli_smoke.py
@@ -1,0 +1,13 @@
+from click.testing import CliRunner
+
+from archive_domain.cli import cli
+
+
+def test_cli_lists_plan_and_run_commands():
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "plan" in result.output
+    assert "run" in result.output

--- a/samples/python/archive-domain/tests/test_db_runner.py
+++ b/samples/python/archive-domain/tests/test_db_runner.py
@@ -1,0 +1,211 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from archive_domain.config import (
+    ArchiveConfig,
+    DatabaseConfig,
+    IotConfig,
+    ObjectStorageConfig,
+)
+from archive_domain.db import choose_execution_mode
+from archive_domain.executor import LiveArchiveExecutor
+from archive_domain.models import DatasetPlan
+
+
+def test_choose_execution_mode_uses_sql_when_bulk_mode_is_unavailable():
+    mode = choose_execution_mode(
+        requested_mode="bulk",
+        dbms_cloud_available=False,
+        has_db_export_credentials=True,
+    )
+
+    assert mode == "sql"
+
+
+def test_choose_execution_mode_retains_bulk_when_prerequisites_exist():
+    mode = choose_execution_mode(
+        requested_mode="bulk",
+        dbms_cloud_available=True,
+        has_db_export_credentials=True,
+    )
+
+    assert mode == "bulk"
+
+
+def _build_config(export_format: str = "parquet") -> ArchiveConfig:
+    return ArchiveConfig(
+        iot=IotConfig(
+            domain_id="ocid1.iotdomain.oc1..exampleuniqueID",
+            retention_days={"raw": 16, "historized": 30, "rejected": 16},
+            bootstrap_lookback_days=1,
+        ),
+        database=DatabaseConfig(
+            connect_string="tcps:adb.example.com:1522/archive_high",
+            token_scope="urn:oracle:db::id::*",
+            iot_domain_short_name="sample",
+            auth_type="SecurityToken",
+            profile="DEFAULT",
+            thick_mode=False,
+            lib_dir=None,
+            dbms_cloud_credential_name="ARCHIVE_CRED",
+        ),
+        object_storage=ObjectStorageConfig(
+            namespace="sample-ns",
+            bucket_name="archive-bucket",
+            prefix="archive-root",
+            manifest_prefix="_manifests",
+            checkpoint_object="_state/checkpoint.json",
+        ),
+        export_format=export_format,
+    )
+
+
+def _build_dataset_plan(
+    name: str, retention_days: int, time_column: str
+) -> DatasetPlan:
+    now = datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc)
+    return DatasetPlan(
+        name=name,
+        retention_days=retention_days,
+        purge_boundary=now,
+        window_start=now,
+        window_end=now,
+    )
+
+
+class _FakeCursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return _FakeCursor()
+
+
+def test_execute_dataset_bulk_uses_parquet_for_bronze_datasets(monkeypatch):
+    captured = []
+
+    def fake_build_bulk_export_request(**kwargs):
+        captured.append(kwargs)
+        return (
+            SimpleNamespace(
+                dataset=kwargs["dataset"],
+                sql_text="select 1 from dual",
+                binds={},
+                time_column="time_received",
+            ),
+            "begin null; end;",
+            {},
+        )
+
+    monkeypatch.setattr(
+        "archive_domain.executor.build_bulk_export_request",
+        fake_build_bulk_export_request,
+    )
+    monkeypatch.setattr(
+        "archive_domain.executor.connect", lambda _cfg: _FakeConnection()
+    )
+    monkeypatch.setattr(
+        "archive_domain.executor.set_current_schema", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "archive_domain.executor.execute_statement", lambda *_args, **_kwargs: None
+    )
+
+    executor = LiveArchiveExecutor(
+        config=_build_config(export_format="parquet"),
+        object_storage_client=SimpleNamespace(),
+        namespace="sample-ns",
+        region="us-phoenix-1",
+    )
+
+    raw_result = executor.execute_dataset(
+        dataset="raw",
+        dataset_plan=_build_dataset_plan("raw", 16, "time_received"),
+        mode="bulk",
+        object_prefix="archive-root/raw",
+        export_format="parquet",
+    )
+    rejected_result = executor.execute_dataset(
+        dataset="rejected",
+        dataset_plan=_build_dataset_plan("rejected", 16, "time_received"),
+        mode="bulk",
+        object_prefix="archive-root/rejected",
+        export_format="parquet",
+    )
+
+    assert [item["export_format"] for item in captured] == ["parquet", "parquet"]
+    assert raw_result.export_mode == "bulk"
+    assert raw_result.export_format == "parquet"
+    assert rejected_result.export_mode == "bulk"
+    assert rejected_result.export_format == "parquet"
+
+
+def test_execute_dataset_sql_mode_routes_to_direct_query_for_parquet(monkeypatch):
+    executor = LiveArchiveExecutor(
+        config=_build_config(export_format="parquet"),
+        object_storage_client=SimpleNamespace(),
+        namespace="sample-ns",
+        region="us-phoenix-1",
+    )
+    captured = []
+
+    def fake_execute_sql(dataset, dataset_plan, object_prefix, export_format):
+        captured.append(
+            {
+                "dataset": dataset,
+                "dataset_plan": dataset_plan,
+                "object_prefix": object_prefix,
+                "export_format": export_format,
+            }
+        )
+        return SimpleNamespace(
+            name=dataset,
+            status="succeeded",
+            export_mode="sql",
+            export_format=export_format,
+            object_prefix=object_prefix,
+        )
+
+    monkeypatch.setattr(executor, "_execute_sql", fake_execute_sql)
+
+    result = executor.execute_dataset(
+        dataset="raw",
+        dataset_plan=_build_dataset_plan("raw", 16, "time_received"),
+        mode="sql",
+        object_prefix="archive-root/raw",
+        export_format="parquet",
+    )
+
+    assert result.export_mode == "sql"
+    assert captured[0]["export_format"] == "parquet"
+
+
+def test_execute_dataset_sql_mode_rejects_datapump():
+    executor = LiveArchiveExecutor(
+        config=_build_config(export_format="datapump"),
+        object_storage_client=SimpleNamespace(),
+        namespace="sample-ns",
+        region="us-phoenix-1",
+    )
+
+    with pytest.raises(RuntimeError, match="sql mode supports only parquet exports"):
+        executor.execute_dataset(
+            dataset="raw",
+            dataset_plan=_build_dataset_plan("raw", 16, "time_received"),
+            mode="sql",
+            object_prefix="archive-root/raw",
+            export_format="datapump",
+        )

--- a/samples/python/archive-domain/tests/test_exporters.py
+++ b/samples/python/archive-domain/tests/test_exporters.py
@@ -1,0 +1,187 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from archive_domain.exporters import (
+    build_bulk_export_request,
+    export_format_for_dataset,
+)
+from archive_domain.sql import build_dataset_query
+
+
+def test_export_format_for_dataset_uses_configured_run_format():
+    assert export_format_for_dataset("raw", "parquet") == "parquet"
+    assert export_format_for_dataset("rejected", "parquet") == "parquet"
+    assert export_format_for_dataset("historized", "datapump") == "datapump"
+
+
+def test_parquet_raw_and_rejected_queries_project_blob_content_as_json():
+    window_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc)
+
+    raw_query = build_dataset_query(
+        "raw",
+        window_start,
+        window_end,
+        domain_short_name="sample",
+        export_format="parquet",
+    )
+    rejected_query = build_dataset_query(
+        "rejected",
+        window_start,
+        window_end,
+        domain_short_name="sample",
+        export_format="parquet",
+    )
+
+    assert "content_type" in raw_query.sql_text
+    assert "content_encoding" in raw_query.sql_text
+    assert "content_representation" in raw_query.sql_text
+    assert " is json strict" in raw_query.sql_text
+    assert "json_exists(" not in raw_query.sql_text
+    assert "'json'" in raw_query.sql_text
+    assert "'text'" in raw_query.sql_text
+    assert "'base64'" in raw_query.sql_text
+    assert "'parsed-json'" in raw_query.sql_text
+    assert "'json-string'" in raw_query.sql_text
+    assert "'base64-string'" in raw_query.sql_text
+    assert "blob_to_json(content, content_type) as content" in raw_query.sql_text
+    assert "ords_utils" not in raw_query.sql_text
+    assert "blobToJson" not in raw_query.sql_text
+    assert "time_received >= :window_start" in raw_query.sql_text
+    assert "time_received < :window_end" in raw_query.sql_text
+
+    assert "reason_code" in rejected_query.sql_text
+    assert "reason_message" in rejected_query.sql_text
+    assert "content_encoding" in rejected_query.sql_text
+    assert "content_representation" in rejected_query.sql_text
+    assert "blob_to_json(content, content_type) as content" in rejected_query.sql_text
+    assert "ords_utils" not in rejected_query.sql_text
+    assert "blobToJson" not in rejected_query.sql_text
+
+
+def test_parquet_blob_content_conversion_does_not_require_domain_short_name():
+    window_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc)
+
+    raw_query = build_dataset_query(
+        "raw", window_start, window_end, export_format="parquet"
+    )
+
+    assert "blob_to_json(content, content_type) as content" in raw_query.sql_text
+
+
+def test_datapump_raw_and_rejected_queries_preserve_table_rows():
+    window_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc)
+
+    raw_query = build_dataset_query(
+        "raw", window_start, window_end, export_format="datapump"
+    )
+    rejected_query = build_dataset_query(
+        "rejected", window_start, window_end, export_format="datapump"
+    )
+
+    assert raw_query.sql_text.startswith("select *")
+    assert "from raw_data" in raw_query.sql_text
+    assert "blob_to_json" not in raw_query.sql_text
+    assert "blobToJson" not in raw_query.sql_text
+
+    assert rejected_query.sql_text.startswith("select *")
+    assert "from rejected_data" in rejected_query.sql_text
+    assert "blob_to_json" not in rejected_query.sql_text
+    assert "blobToJson" not in rejected_query.sql_text
+
+
+def test_parquet_historized_query_remains_explicit_and_json_friendly():
+    window_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc)
+
+    historized_query = build_dataset_query(
+        "historized", window_start, window_end, export_format="parquet"
+    )
+
+    assert historized_query.sql_text.startswith("select")
+    assert (
+        "json_serialize(value returning varchar2(32767)) as value_json"
+        in historized_query.sql_text
+    )
+    assert "from historized_data" in historized_query.sql_text
+    assert "time_observed >= :window_start" in historized_query.sql_text
+    assert "time_observed < :window_end" in historized_query.sql_text
+
+
+def test_bulk_export_request_inlines_window_literals_for_dbms_cloud():
+    window_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+    window_end = datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc)
+
+    _query, _statement, binds = build_bulk_export_request(
+        dataset="raw",
+        window_start=window_start,
+        window_end=window_end,
+        credential_name="archive_credential",
+        file_uri_list="https://object.example/exports/raw",
+        domain_short_name="sample",
+        export_format="parquet",
+    )
+
+    assert set(binds) == {
+        "credential_name",
+        "export_format",
+        "file_uri_list",
+        "query_text",
+    }
+    assert binds["export_format"] == "parquet"
+    assert ":window_start" not in binds["query_text"]
+    assert ":window_end" not in binds["query_text"]
+    assert "to_timestamp_tz('2026-04-01T00:00:00.000000+00:00'" in binds["query_text"]
+    assert "to_timestamp_tz('2026-04-02T00:00:00.000000+00:00'" in binds["query_text"]
+    assert "content_encoding" in binds["query_text"]
+    assert "content_representation" in binds["query_text"]
+    assert "blob_to_json(content, content_type) as content" in binds["query_text"]
+    assert "ords_utils" not in binds["query_text"]
+    assert "blobToJson" not in binds["query_text"]
+
+
+def test_sql_sample_uses_public_blob_to_json_api():
+    sample_root = Path(__file__).resolve().parents[3]
+    sql_package = (
+        sample_root / "sql" / "archive-domain" / "archive_domain_pkg.sql"
+    ).read_text()
+    sql_readme = (sample_root / "sql" / "archive-domain" / "README.md").read_text()
+
+    for content in (sql_package, sql_readme):
+        assert "blob_to_json(content, content_type)" in content
+        assert "ords_utils.blobToJson" not in content
+
+    assert "public OCI IoT Platform API" in sql_readme
+
+
+def test_sql_sample_does_not_gate_datapump_availability():
+    sample_root = Path(__file__).resolve().parents[3]
+    sql_package = (
+        sample_root / "sql" / "archive-domain" / "archive_domain_pkg.sql"
+    ).read_text()
+
+    assert "c_enable_datapump" not in sql_package
+    assert "datapump export format is not enabled for this platform" not in sql_package
+    assert "datapump export format requires exactly one dataset per run" in sql_package
+
+
+def test_sql_sample_documents_datapump_one_dataset_rule_and_sql_loader_dependency():
+    sample_root = Path(__file__).resolve().parents[3]
+    sql_readme = (sample_root / "sql" / "archive-domain" / "README.md").read_text()
+    sql_config = (
+        sample_root / "sql" / "archive-domain" / "data" / "archive_config.distr.json"
+    ).read_text()
+
+    assert "Data Pump runs require selecting exactly one dataset" in sql_readme
+    assert "python-oracledb" in sql_readme
+    assert '"dbms_cloud_credential_name": "DOMAIN_ARCHIVE_TEST"' in sql_config
+
+
+def test_sql_sample_describes_dbms_cloud_access_as_api_key_not_principal():
+    sample_root = Path(__file__).resolve().parents[3]
+    sql_readme = (sample_root / "sql" / "archive-domain" / "README.md").read_text()
+
+    assert "SQL uses the API key stored in the `DBMS_CLOUD` credential" in sql_readme
+    assert "OCI principal behind the `DBMS_CLOUD` credential" not in sql_readme

--- a/samples/python/archive-domain/tests/test_object_storage_state.py
+++ b/samples/python/archive-domain/tests/test_object_storage_state.py
@@ -1,0 +1,93 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from archive_domain.object_storage import (
+    ObjectStorageStateStore,
+    build_dataset_object_prefix,
+    should_advance_checkpoint,
+)
+
+
+class _FakeObjectStorageError(Exception):
+    def __init__(self, status=None, code=None):
+        super().__init__("simulated object storage error")
+        self.status = status
+        self.code = code
+
+
+class _FakeGetObjectResponse:
+    def __init__(self, payload: str):
+        self.data = type("Data", (), {"content": payload.encode("utf-8")})()
+
+
+class _FakeObjectStorageClient:
+    def __init__(self, response=None, exc=None):
+        self.response = response
+        self.exc = exc
+
+    def get_object(self, **_kwargs):
+        if self.exc is not None:
+            raise self.exc
+        return self.response
+
+
+def test_checkpoint_advances_only_when_all_selected_datasets_succeed():
+    statuses = {"raw": "succeeded", "historized": "failed"}
+
+    assert should_advance_checkpoint(statuses) is False
+    assert should_advance_checkpoint({"raw": "succeeded", "historized": "succeeded"})
+    assert should_advance_checkpoint({}) is False
+
+
+def test_build_dataset_object_prefix_partitions_by_domain_dataset_and_hour():
+    run_at = datetime(2026, 4, 8, 12, 34, tzinfo=timezone.utc)
+
+    object_prefix = build_dataset_object_prefix(
+        prefix="iot-archive",
+        domain_short_name="demo",
+        zone="bronze",
+        dataset="raw",
+        run_id="run-123",
+        run_at=run_at,
+    )
+
+    assert object_prefix == (
+        "iot-archive/domain=demo/zone=bronze/dataset=raw/"
+        "year=2026/month=04/day=08/hour=12/run_id=run-123"
+    )
+
+
+def test_load_checkpoint_returns_empty_state_only_for_not_found():
+    store = ObjectStorageStateStore(
+        client=_FakeObjectStorageClient(exc=_FakeObjectStorageError(status=404)),
+        namespace="sample-ns",
+        bucket_name="archive-bucket",
+    )
+
+    checkpoint = store.load_checkpoint("_state/checkpoint.json")
+
+    assert checkpoint.last_successful_run_at is None
+
+
+def test_load_checkpoint_raises_for_non_not_found_errors():
+    store = ObjectStorageStateStore(
+        client=_FakeObjectStorageClient(exc=_FakeObjectStorageError(status=500)),
+        namespace="sample-ns",
+        bucket_name="archive-bucket",
+    )
+
+    with pytest.raises(_FakeObjectStorageError):
+        store.load_checkpoint("_state/checkpoint.json")
+
+
+def test_load_checkpoint_raises_for_malformed_json():
+    store = ObjectStorageStateStore(
+        client=_FakeObjectStorageClient(response=_FakeGetObjectResponse("{not-json}")),
+        namespace="sample-ns",
+        bucket_name="archive-bucket",
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        store.load_checkpoint("_state/checkpoint.json")

--- a/samples/python/archive-domain/tests/test_planner.py
+++ b/samples/python/archive-domain/tests/test_planner.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from archive_domain.planner import build_archive_plan, parse_datasets
+
+
+def test_build_archive_plan_computes_newly_at_risk_window_per_dataset():
+    now = datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc)
+    last_success = now - timedelta(days=1)
+
+    plan = build_archive_plan(
+        selected_datasets=["raw", "historized"],
+        retention_days={"raw": 16, "historized": 30},
+        now=now,
+        last_successful_run_at=last_success,
+    )
+
+    assert plan.datasets["raw"].window_end == now - timedelta(days=16)
+    assert plan.datasets["raw"].window_start == last_success - timedelta(days=16)
+    assert plan.datasets["historized"].window_end == now - timedelta(days=30)
+    assert plan.datasets["historized"].window_start == last_success - timedelta(days=30)
+
+
+def test_build_archive_plan_uses_bootstrap_lookback_for_first_run():
+    now = datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc)
+
+    plan = build_archive_plan(
+        selected_datasets=["raw"],
+        retention_days={"raw": 16},
+        now=now,
+        bootstrap_lookback_days=2,
+    )
+
+    assert plan.datasets["raw"].window_end == now - timedelta(days=16)
+    assert plan.datasets["raw"].window_start == now - timedelta(days=18)
+
+
+def test_parse_datasets_normalizes_and_validates_values():
+    assert parse_datasets("rejected, raw ,historized") == (
+        "raw",
+        "historized",
+        "rejected",
+    )
+
+    with pytest.raises(ValueError, match="Unknown datasets"):
+        parse_datasets("raw,unknown")

--- a/samples/python/archive-domain/tests/test_readme.py
+++ b/samples/python/archive-domain/tests/test_readme.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+def test_readme_mentions_supported_datasets_and_modes():
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text()
+
+    assert "raw" in readme
+    assert "historized" in readme
+    assert "rejected" in readme
+    assert "bulk" in readme
+    assert "sql" in readme
+    assert "parquet" in readme
+    assert "content_encoding" in readme
+    assert "content_representation" in readme
+    assert "DBMS_CLOUD.EXPORT_DATA" in readme
+    assert "--dry-run" in readme
+    assert "samples/python/archive-domain/data/archive_config.yaml" in readme
+    assert "Data Pump runs require selecting exactly one dataset" in readme
+    assert "DOMAIN_ARCHIVE_TEST" in readme

--- a/samples/python/archive-domain/tests/test_retention_lookup.py
+++ b/samples/python/archive-domain/tests/test_retention_lookup.py
@@ -1,0 +1,29 @@
+from archive_domain.iot_domain import resolve_retention_days
+
+
+class _FailingLookup:
+    def get_retention_days(self):
+        raise RuntimeError("lookup failed")
+
+
+class _PartialLookup:
+    def get_retention_days(self):
+        return {"raw": 16, "historized": 30}
+
+
+def test_resolve_retention_days_falls_back_to_config_values():
+    retention = resolve_retention_days(
+        lookup_client=_FailingLookup(),
+        configured_overrides={"raw": 10, "historized": 20, "rejected": 30},
+    )
+
+    assert retention == {"raw": 10, "historized": 20, "rejected": 30}
+
+
+def test_resolve_retention_days_merges_live_lookup_and_overrides():
+    retention = resolve_retention_days(
+        lookup_client=_PartialLookup(),
+        configured_overrides={"raw": None, "historized": None, "rejected": 12},
+    )
+
+    assert retention == {"raw": 16, "historized": 30, "rejected": 12}

--- a/samples/python/archive-domain/tests/test_service.py
+++ b/samples/python/archive-domain/tests/test_service.py
@@ -1,0 +1,192 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from archive_domain.config import (
+    ArchiveConfig,
+    DatabaseConfig,
+    IotConfig,
+    ObjectStorageConfig,
+    load_config,
+)
+from archive_domain.models import CheckpointState
+from archive_domain.service import ArchiveService
+
+
+class _StaticRetentionLookup:
+    def get_retention_days(self):
+        return {"raw": 16, "historized": 30, "rejected": 16}
+
+
+class _MemoryStateStore:
+    def __init__(self):
+        self.objects = {}
+        self.saved_checkpoints = []
+
+    def load_checkpoint(self, _object_name):
+        return CheckpointState()
+
+    def put_json_object(self, object_name, payload):
+        self.objects[object_name] = payload
+
+    def save_checkpoint(self, object_name, checkpoint):
+        self.saved_checkpoints.append((object_name, checkpoint))
+
+
+class _FailingExecutor:
+    def execute_dataset(self, **_kwargs):
+        raise RuntimeError("simulated export failure")
+
+
+def _build_config(export_format: str = "parquet"):
+    return ArchiveConfig(
+        iot=IotConfig(
+            domain_id="ocid1.iotdomain.oc1..exampleuniqueID",
+            retention_days={"raw": 16, "historized": 30, "rejected": 16},
+            bootstrap_lookback_days=1,
+        ),
+        database=DatabaseConfig(
+            connect_string="tcps:adb.example.com:1522/archive_high",
+            token_scope="urn:oracle:db::id::*",
+            iot_domain_short_name="sample",
+            auth_type="SecurityToken",
+            profile="DEFAULT",
+            thick_mode=False,
+            lib_dir=None,
+            dbms_cloud_credential_name="ARCHIVE_CRED",
+        ),
+        object_storage=ObjectStorageConfig(
+            namespace="sample-ns",
+            bucket_name="archive-bucket",
+            prefix="archive-root",
+            manifest_prefix="_manifests",
+            checkpoint_object="_state/checkpoint.json",
+        ),
+        export_format=export_format,
+    )
+
+
+def _build_plan_service(config):
+    return ArchiveService(
+        config=config,
+        retention_lookup=_StaticRetentionLookup(),
+    )
+
+
+def test_run_records_failed_dataset_and_writes_manifest_without_advancing_checkpoint():
+    state_store = _MemoryStateStore()
+    service = ArchiveService(
+        config=_build_config(),
+        retention_lookup=_StaticRetentionLookup(),
+        state_store=state_store,
+        executor=_FailingExecutor(),
+        clock=lambda: datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc),
+    )
+
+    result = service.run(datasets="raw")
+
+    assert result.checkpoint_advanced is False
+    assert result.dataset_results[0].name == "raw"
+    assert result.dataset_results[0].status == "failed"
+    assert result.dataset_results[0].error_message == "simulated export failure"
+    assert result.manifest_object_name in state_store.objects
+    assert state_store.saved_checkpoints == []
+
+
+def test_load_config_reads_run_level_export_format(tmp_path):
+    config_path = tmp_path / "archive_config.yaml"
+    config_path.write_text(
+        """
+export_format: parquet
+iot:
+  domain_id: ocid1.iotdomain.oc1..exampleuniqueID
+  retention_days:
+    raw: 16
+  bootstrap_lookback_days: 1
+database:
+  connect_string: "tcps:adb.example.com:1522/archive_high"
+  token_scope: "urn:oracle:db::id::*"
+  iot_domain_short_name: sample
+  auth_type: SecurityToken
+  profile: DEFAULT
+  thick_mode: false
+  lib_dir: null
+  dbms_cloud_credential_name: ARCHIVE_CRED
+object_storage:
+  namespace: sample-ns
+  bucket_name: archive-bucket
+  prefix: archive-root
+  manifest_prefix: _manifests
+  checkpoint_object: _state/checkpoint.json
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.export_format == "parquet"
+
+
+def test_distributed_config_template_defaults_to_parquet():
+    template = (
+        Path(__file__).resolve().parents[1] / "data" / "archive_config.distr.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert "export_format: parquet" in template
+    assert "dbms_cloud_credential_name: DOMAIN_ARCHIVE_TEST" in template
+
+
+def test_run_allows_datapump():
+    service = _build_plan_service(_build_config(export_format="datapump"))
+
+    result = service.run(datasets="raw", dry_run=True)
+
+    assert result.export_format == "datapump"
+    assert result.dataset_results[0].export_format == "datapump"
+
+
+def test_plan_rejects_multiple_datasets_for_datapump():
+    service = _build_plan_service(_build_config(export_format="datapump"))
+
+    with pytest.raises(
+        ValueError,
+        match="datapump export format requires selecting exactly one dataset",
+    ):
+        service.plan(datasets="raw,historized")
+
+
+def test_plan_rejects_empty_normalized_dataset_selection():
+    service = _build_plan_service(_build_config(export_format="parquet"))
+
+    with pytest.raises(ValueError, match="Dataset list cannot be empty"):
+        service.plan(datasets=" , , ")
+
+
+def test_plan_allows_multiple_datasets_for_parquet():
+    service = ArchiveService(
+        config=_build_config(export_format="parquet"),
+        retention_lookup=_StaticRetentionLookup(),
+        clock=lambda: datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc),
+    )
+
+    result = service.plan(datasets="raw,historized")
+
+    assert result.export_format == "parquet"
+    assert result.plan.selected_datasets == ("raw", "historized")
+
+
+def test_run_does_not_advance_checkpoint_for_empty_status_map():
+    state_store = _MemoryStateStore()
+    service = ArchiveService(
+        config=_build_config(export_format="parquet"),
+        retention_lookup=_StaticRetentionLookup(),
+        state_store=state_store,
+        executor=_FailingExecutor(),
+        clock=lambda: datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ValueError, match="Dataset list cannot be empty"):
+        service.run(datasets=" , , ")
+
+    assert state_store.saved_checkpoints == []

--- a/samples/python/archive-domain/tests/test_sql_load_config.py
+++ b/samples/python/archive-domain/tests/test_sql_load_config.py
@@ -1,0 +1,75 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_sql_config_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "sql"
+        / "archive-domain"
+        / "load_config.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "archive_sql_load_config", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.statements = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, statement, **binds):
+        self.statements.append((statement, binds))
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.cursor_obj = _FakeCursor()
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+
+def test_sql_load_config_commits_successful_upsert(tmp_path, monkeypatch):
+    module = _load_sql_config_module()
+    config_path = tmp_path / "archive_config.json"
+    config_path.write_text('{"export_format":"parquet"}', encoding="utf-8")
+    connection = _FakeConnection()
+
+    monkeypatch.setattr(module, "connect", lambda _args: connection)
+    monkeypatch.setattr(
+        module,
+        "parse_args",
+        lambda: module.argparse.Namespace(
+            config_file=config_path,
+            config_name="default",
+            proxy_user="KBCB5B66BKIW6__WKSP",
+            connect_string="tcps:adb.example.com:1521/service",
+            token_scope="urn:oracle:db::id::*",
+            auth_type="InstancePrincipal",
+            profile="DEFAULT",
+        ),
+    )
+
+    module.main()
+
+    assert connection.committed is True

--- a/samples/python/command-response/config.distr.py
+++ b/samples/python/command-response/config.distr.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-# Configuration file
+
+"""
+Configuration template for the command-response sample.
+
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
 
 # Device host.
 # The device host is an IoT Domain property and can be retrieved using:

--- a/samples/python/publish-https/config.distr.py
+++ b/samples/python/publish-https/config.distr.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-# Configuration file
+
+"""
+Configuration template for the HTTPS publish sample.
+
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
 
 # Device host.
 # The device host is an IoT Domain property and can be retrieved using:

--- a/samples/python/publish-mqtt/config.distr.py
+++ b/samples/python/publish-mqtt/config.distr.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-# Configuration file
+
+"""
+Configuration template for the MQTT publish sample.
+
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
 
 # Device host.
 # The device host is an IoT Domain property and can be retrieved using:

--- a/samples/python/publish-websockets/config.distr.py
+++ b/samples/python/publish-websockets/config.distr.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-# Configuration file
+
+"""
+Configuration template for the WebSocket publish sample.
+
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
 
 # Device host.
 # The device host is an IoT Domain property and can be retrieved using:

--- a/samples/python/query-db/config.distr.py
+++ b/samples/python/query-db/config.distr.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-# Configuration file
+
+"""
+Configuration template for the direct database query sample.
+
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
 import os
 
 # Database connect string and token scope as provided by the OCI IoT Platform.

--- a/samples/python/queues/config.distr.py
+++ b/samples/python/queues/config.distr.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Configuration constants for the IoT Platform queue samples.
 
+Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
 This file defines database and authentication parameters. Copy and rename to
 config.py, then edit values as needed.
 

--- a/samples/sql/archive-domain/.gitignore
+++ b/samples/sql/archive-domain/.gitignore
@@ -1,0 +1,1 @@
+/data/archive_config.json

--- a/samples/sql/archive-domain/README.md
+++ b/samples/sql/archive-domain/README.md
@@ -1,0 +1,302 @@
+# Archive IoT Domain Data To Object Storage From SQL
+
+This DB-driven sample lets you plan and run the archive-domain workflow entirely
+from the database using `archive_domain_pkg.plan` and
+`archive_domain_pkg.run`. The package lives in the `<DomainShortId>__WKSP`
+schema, reads configuration from `archive_domain_config`, and writes datasets
+to Object Storage with `DBMS_CLOUD` APIs.
+
+## Shared Concepts
+
+This section applies to both the SQL sample in this directory and the Python
+sample in [../../python/archive-domain/README.md](../../python/archive-domain/README.md).
+
+### Plan And Run
+
+Both implementations follow the same archive workflow:
+
+- `plan` computes the archive windows for the selected datasets.
+- `run` exports the selected datasets to Object Storage, writes a manifest, and
+  advances the checkpoint only when every selected dataset succeeds.
+
+### Export Formats
+
+The archive format is chosen once per run from configuration with
+`export_format`.
+
+#### Parquet
+
+- The public default is `parquet`.
+- `parquet` applies to `raw`, `historized`, and `rejected`.
+- For `parquet`, `raw` and `rejected` project the `content` column through
+  `blob_to_json(content, content_type)`.
+- `blob_to_json` is a public OCI IoT Platform API exposed in the domain schema.
+- Parquet `raw` and `rejected` exports also include:
+  - `content_encoding`
+  - `content_representation`
+- Use these companion columns together with `content_type` to
+  interpret `content` safely.
+- JSON-looking payloads are classified as `json` / `parsed-json` only when the
+  payload is strict JSON. Malformed `application/json` payloads fall back to
+  `base64` / `base64-string`.
+
+#### Data Pump
+
+- `datapump` is also a supported run-level export format.
+- `datapump` applies to `raw`, `historized`, and `rejected`.
+- Use `datapump` when you want native Oracle database exports rather than
+  Parquet representations.
+- Data Pump runs require selecting exactly one dataset. Use Parquet when you
+  want one run to archive multiple datasets.
+
+### Datasets, Retention, And Archive Windows
+
+Both implementations operate on the same datasets:
+
+- `raw`
+- `historized`
+- `rejected`
+
+The IoT Platform purges data according to dataset-specific retention periods,
+configured by the IoT domain administrator.
+Both implementations use those retention values to compute the purge boundary
+for each dataset (`now - retention_days`) and then derive the archive window by
+determining which data is at risk of being purged:
+
+- explicit `start` / `end` overrides when provided
+- the last successful checkpoint in Object Storage
+- the configured bootstrap lookback when no checkpoint exists yet
+
+### Object Storage Layout And State
+
+The archive writes dataset exports into a partitioned Object Storage layout
+organized by domain, zone, dataset, and time window.
+
+Both implementations write:
+
+- dataset exports under `domain=<...>/zone=<...>/dataset=<...>/...`
+- a manifest object under `<prefix>/_manifests/run_id=<...>.json`
+- a checkpoint object under `<prefix>/_state/checkpoint.json`
+
+The checkpoint advances only after all selected datasets succeed.
+
+### Bucket Access Guidance
+
+Both implementations need credentials that can write to the target Object
+Storage bucket. The credential path differs by implementation:
+
+- SQL uses the API key stored in the `DBMS_CLOUD` credential.
+- Python uses the compute or operator identity that runs the sample, and bulk
+  mode also needs a `DBMS_CLOUD` credential for database-side export.
+
+Whichever credential or identity is writing to the bucket must be able to:
+
+- read bucket metadata for the target bucket
+- create objects in the target bucket
+- overwrite objects in the target bucket when rerunning the same checkpoint or
+  manifest object names
+- read objects again if you want to validate manifests and checkpoint files
+  after a run
+
+In same-tenancy setups, the broad policy pattern is:
+
+```text
+Allow <group-or-user-scope> to read buckets in compartment <bucket_compartment>
+  where target.bucket.name = '<bucket_name>'
+
+Allow <group-or-user-scope> to manage objects in compartment <bucket_compartment>
+  where target.bucket.name = '<bucket_name>'
+```
+
+## SQL-Specific Notes
+
+The SQL sample reads `export_format` from `archive_domain_config.config_json`.
+With the distributed sample config, all selected datasets export as Parquet.
+Set `export_format` to `datapump` when you want Data Pump output instead.
+
+## Prerequisites
+
+- An IoT Domain
+- A workspace database user configured to connect with `WKSP_PROXY_USER`. See
+  [samples/script/query-db/README.md](../../script/query-db/README.md) for the
+  connection flow used here.
+- A `DBMS_CLOUD` credential that can write to the archive bucket. The sample
+  uses the placeholder name `DOMAIN_ARCHIVE_TEST`, which is the same name
+  referenced from the sample config. Create it with
+  `DBMS_CLOUD.CREATE_CREDENTIAL` before calling the package routines.
+- Object Storage namespace/bucket for checkpoints and manifests. The config row
+  seeds `prefix` values such as `<bucket>/<prefix>` and
+  `_state/checkpoint.json`.
+- Python 3 with `python-oracledb` installed for `load_config.py`. For example,
+  run `python3 -m pip install 'oracledb~=3.0'` in the environment you use to
+  load the sample config.
+
+## Install / Teardown
+
+1. To install, run:
+
+   ```sh
+   sql "jdbc:oracle:thin:[${WKSP_PROXY_USER}]/@${IOT_DB_CONNECT_STRING}&TOKEN_AUTH=OCI_TOKEN" @samples/sql/archive-domain/install.sql
+   ```
+
+   This pulls in `archive_domain_tables.sql`, installs
+   `archive_domain_config`, and creates the `archive_domain_pkg`.
+2. When you are finished, drop the package and helper tables with:
+
+   ```sh
+   sql "jdbc:oracle:thin:[${WKSP_PROXY_USER}]/@${IOT_DB_CONNECT_STRING}&TOKEN_AUTH=OCI_TOKEN" @samples/sql/archive-domain/teardown.sql
+   ```
+
+## Configuration
+
+The package reads every runtime setting from `archive_domain_config`:
+
+- `config_name`: Logical identifier, defaults to `default`.
+- `config_json`: JSON payload that points to domain IDs,
+  bucket/namespace/prefix, checkpoint object, DBMS_CLOUD credential name,
+  run-level `export_format`, retention days per dataset, and bootstrap
+  lookback.
+
+To configure the sample, copy:
+
+```text
+samples/sql/archive-domain/data/archive_config.distr.json
+```
+
+to:
+
+```text
+samples/sql/archive-domain/data/archive_config.json
+```
+
+Edit the JSON file with your real values, then load it into
+`archive_domain_config` with:
+
+```sh
+python3 samples/sql/archive-domain/load_config.py \
+  --config-file samples/sql/archive-domain/data/archive_config.json \
+  --config-name default \
+  --proxy-user "${WKSP_PROXY_USER}" \
+  --connect-string "${IOT_DB_CONNECT_STRING}" \
+  --token-scope "${IOT_DB_TOKEN_SCOPE}" \
+  --auth-type InstancePrincipal
+```
+
+On a workstation using a config-file-backed OCI identity instead of instance
+principal, use:
+
+```sh
+python3 samples/sql/archive-domain/load_config.py \
+  --config-file samples/sql/archive-domain/data/archive_config.json \
+  --config-name default \
+  --proxy-user "${WKSP_PROXY_USER}" \
+  --connect-string "${IOT_DB_CONNECT_STRING}" \
+  --token-scope "${IOT_DB_TOKEN_SCOPE}" \
+  --auth-type ConfigFileAuthentication \
+  --profile "${OCI_CLI_PROFILE:-DEFAULT}"
+```
+
+The distributed JSON template includes placeholders for the bucket layout and
+uses `DOMAIN_ARCHIVE_TEST` as the placeholder `dbms_cloud_credential_name`.
+It defaults `export_format` to `parquet` and is the recommended starting point
+for operator-managed configuration. Change `export_format` to `datapump` when
+you want Data Pump exports for the selected run, and select only one dataset
+for each Data Pump run.
+
+## Planning With `archive_domain_pkg.plan`
+
+Start with `archive_domain_pkg.plan`. It inspects the retention policy,
+checkpoint state, and optional `start` / `end` overrides before returning a
+JSON payload of proposed windows for each dataset:
+
+```sql
+set serveroutput on size unlimited
+declare
+  l_result clob;
+begin
+  archive_domain_pkg.plan(
+    p_config_name  => 'default',
+    p_dataset_list => 'raw,historized',
+    p_result       => l_result
+  );
+  dbms_output.put_line(l_result);
+end;
+/
+```
+
+`archive_domain_pkg.plan` triggers these steps:
+
+1. Load the named config row from `archive_domain_config`.
+2. Parse and validate the requested dataset list.
+3. Read the checkpoint object from Object Storage when it exists.
+4. Resolve per-dataset retention values from `config_json`.
+5. Compute the effective archive window for each dataset:
+   - `window_start`
+   - `window_end`
+   - `purge_boundary`
+6. Return the plan as JSON.
+
+`plan` does **not** export data, write manifests, or advance the checkpoint.
+
+Inspect `$.datasets.<name>.window_start` / `window_end` plus
+`checkpoint_before` to validate the plan and decide which datasets to run.
+
+## Running With `archive_domain_pkg.run`
+
+`archive_domain_pkg.run` reads the run-level `export_format` from config,
+exports the selected datasets through `DBMS_CLOUD.EXPORT_DATA`, writes a JSON
+manifest under `<prefix>/_manifests/run_id=<...>.json`, and advances the
+checkpoint at `<prefix>/_state/checkpoint.json` only after all exports succeed:
+
+```sql
+set serveroutput on size unlimited
+declare
+  l_result clob;
+begin
+  archive_domain_pkg.run(
+    p_config_name  => 'default',
+    p_dataset_list => 'raw',
+    p_result       => l_result
+  );
+  dbms_output.put_line(l_result);
+end;
+/
+```
+
+`archive_domain_pkg.run` triggers these steps:
+
+1. Load the named config row from `archive_domain_config`.
+2. Reuse the same planning logic as `archive_domain_pkg.plan` to determine the
+   archive window.
+3. Build a `run_id` and dataset-specific object prefixes.
+4. For each selected dataset:
+   - build the dataset query
+   - export with the configured run-level format
+5. Write a manifest JSON object to Object Storage.
+6. Write the checkpoint JSON only if every selected dataset succeeded.
+7. Return the run result as JSON, including per-dataset statuses and the
+   manifest object name.
+
+The returned JSON includes per-dataset statuses, per-dataset `export_format`,
+and the manifest path. Re-run with a different `p_dataset_list` or `p_end_time`
+to export additional windows.
+
+## Manual Validation & Object Storage Verification
+
+1. Confirm the config row exists:
+   `select config_json from archive_domain_config where config_name = 'default';`
+2. Run `archive_domain_pkg.plan` and check that `checkpoint_before` equals the
+   last checkpoint in Object Storage.
+3. After running `archive_domain_pkg.run`, list objects under:
+   `oci os object list --namespace <namespace> --bucket <bucket> --prefix <prefix>`
+   and verify:
+   - A manifest JSON appears under `_manifests/run_id=<run-id>.json`.
+   - The checkpoint JSON at `_state/checkpoint.json` reflects the new
+     `last_successful_run_at`.
+   - Dataset exports land under `zone=bronze` / `zone=silver` paths with
+     `dataset=<name>` segments.
+   - `$.datasets.<name>.export_format` matches the configured run-level format.
+   - With `export_format = parquet`, exported objects are Parquet.
+   - With `export_format = datapump`, exported objects are Data Pump dump files.
+4. Re-run `archive_domain_pkg.plan` to ensure the next window uses the updated
+   checkpoint.

--- a/samples/sql/archive-domain/archive_domain_pkg.sql
+++ b/samples/sql/archive-domain/archive_domain_pkg.sql
@@ -1,0 +1,1050 @@
+--
+-- SQL/PLSQL package for the DB-driven archive-domain sample.
+--
+-- Copyright (c) 2026 Oracle and/or its affiliates.
+-- Licensed under the Universal Permissive License v 1.0 as shown at
+-- https://oss.oracle.com/licenses/upl.
+--
+-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+--
+
+create or replace package archive_domain_pkg as
+  procedure plan(
+    p_config_name  in varchar2 default 'default',
+    p_dataset_list in varchar2 default 'raw,historized,rejected',
+    p_start_time   in timestamp with time zone default null,
+    p_end_time     in timestamp with time zone default null,
+    p_result       out clob
+  );
+
+  procedure run(
+    p_config_name  in varchar2 default 'default',
+    p_dataset_list in varchar2 default 'raw,historized,rejected',
+    p_start_time   in timestamp with time zone default null,
+    p_end_time     in timestamp with time zone default null,
+    p_result       out clob
+  );
+end archive_domain_pkg;
+/
+
+show errors
+
+declare
+  l_error_count number;
+begin
+  select count(*)
+    into l_error_count
+    from user_errors
+   where name = 'ARCHIVE_DOMAIN_PKG'
+     and type = 'PACKAGE';
+
+  if l_error_count > 0 then
+    raise_application_error(-20000, 'archive_domain_pkg spec compilation failed');
+  end if;
+end;
+/
+
+create or replace package body archive_domain_pkg as
+  type t_dataset_list is table of varchar2(30) index by pls_integer;
+  type t_seen_map is table of pls_integer index by varchar2(30);
+
+  function format_timestamp(
+    p_value in timestamp with time zone
+  ) return varchar2
+  is
+  begin
+    return to_char(
+      p_value at time zone 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.FF3"Z"'
+    );
+  end format_timestamp;
+
+  function parse_timestamp(
+    p_value in varchar2
+  ) return timestamp with time zone
+  is
+    l_value varchar2(128);
+    l_has_fraction boolean;
+  begin
+    if p_value is null then
+      return null;
+    end if;
+
+    l_value := trim(p_value);
+    if substr(l_value, -1) = 'Z' then
+      l_value := substr(l_value, 1, length(l_value) - 1) || '+00:00';
+    end if;
+
+    l_has_fraction := instr(l_value, '.') > 0;
+
+    if l_has_fraction then
+      return to_timestamp_tz(
+        l_value,
+        'YYYY-MM-DD"T"HH24:MI:SS.FFTZH:TZM'
+      );
+    end if;
+
+    return to_timestamp_tz(
+      l_value,
+      'YYYY-MM-DD"T"HH24:MI:SSTZH:TZM'
+    );
+  exception
+    when others then
+      raise_application_error(-20018, 'invalid checkpoint timestamp: ' || p_value);
+  end parse_timestamp;
+
+  function blob_to_clob(
+    p_value in blob
+  ) return clob
+  is
+    l_result clob;
+    l_dest_offset integer := 1;
+    l_src_offset integer := 1;
+    l_lang_context integer := dbms_lob.default_lang_ctx;
+    l_warning integer;
+  begin
+    if p_value is null then
+      return null;
+    end if;
+
+    dbms_lob.createtemporary(l_result, true);
+    dbms_lob.converttoclob(
+      dest_lob     => l_result,
+      src_blob     => p_value,
+      amount       => dbms_lob.lobmaxsize,
+      dest_offset  => l_dest_offset,
+      src_offset   => l_src_offset,
+      blob_csid    => nls_charset_id('AL32UTF8'),
+      lang_context => l_lang_context,
+      warning      => l_warning
+    );
+    return l_result;
+  end blob_to_clob;
+
+  function clob_to_blob(
+    p_value in clob
+  ) return blob
+  is
+    l_result blob;
+    l_dest_offset integer := 1;
+    l_src_offset integer := 1;
+    l_lang_context integer := dbms_lob.default_lang_ctx;
+    l_warning integer;
+  begin
+    if p_value is null then
+      return null;
+    end if;
+
+    dbms_lob.createtemporary(l_result, true);
+    dbms_lob.converttoblob(
+      dest_lob     => l_result,
+      src_clob     => p_value,
+      amount       => dbms_lob.lobmaxsize,
+      dest_offset  => l_dest_offset,
+      src_offset   => l_src_offset,
+      blob_csid    => nls_charset_id('AL32UTF8'),
+      lang_context => l_lang_context,
+      warning      => l_warning
+    );
+    return l_result;
+  end clob_to_blob;
+
+  function is_not_found_error(
+    p_error_code in number
+  ) return boolean
+  is
+  begin
+    return p_error_code = -20404;
+  end is_not_found_error;
+
+  function parse_datasets(
+    p_dataset_list in varchar2
+  ) return t_dataset_list
+  is
+    l_result t_dataset_list;
+    l_seen t_seen_map;
+    l_token varchar2(128);
+    l_dataset varchar2(30);
+    l_index pls_integer := 1;
+    l_count pls_integer := 0;
+  begin
+    if trim(p_dataset_list) is null then
+      raise_application_error(-20011, 'dataset list cannot be empty');
+    end if;
+
+    loop
+      l_token := regexp_substr(p_dataset_list, '[^,]+', 1, l_index);
+      exit when l_token is null;
+      l_dataset := lower(trim(l_token));
+
+      if l_dataset not in ('raw', 'historized', 'rejected') then
+        raise_application_error(-20012, 'unsupported dataset: ' || l_dataset);
+      end if;
+
+      if not l_seen.exists(l_dataset) then
+        l_count := l_count + 1;
+        l_result(l_count) := l_dataset;
+        l_seen(l_dataset) := 1;
+      end if;
+
+      l_index := l_index + 1;
+    end loop;
+
+    if l_count = 0 then
+      raise_application_error(-20011, 'dataset list cannot be empty');
+    end if;
+
+    return l_result;
+  end parse_datasets;
+
+  function build_stub_result(
+    p_action       in varchar2,
+    p_config_name  in varchar2,
+    p_dataset_list in varchar2
+  ) return clob
+  is
+    l_result clob;
+  begin
+    select json_serialize(
+             json_object(
+               'status' value 'stub',
+               'action' value p_action,
+               'config_name' value p_config_name,
+               'datasets' value json_array(p_dataset_list)
+             )
+             returning clob pretty
+           )
+      into l_result
+      from dual;
+
+    return l_result;
+  end build_stub_result;
+
+  function load_config(
+    p_config_name in varchar2 default 'default'
+  ) return clob
+  is
+    l_config clob;
+  begin
+    select config_json
+      into l_config
+      from archive_domain_config
+     where config_name = p_config_name;
+
+    return l_config;
+  exception
+    when no_data_found then
+      raise_application_error(-20010, 'archive_domain_config missing config: ' || p_config_name);
+  end load_config;
+
+  function resolve_retention_days(
+    p_config  in clob,
+    p_dataset in varchar2
+  ) return pls_integer
+  is
+    l_config_obj json_object_t;
+    l_retention_obj json_object_t;
+    l_retention_days pls_integer;
+  begin
+    l_config_obj := json_object_t.parse(p_config);
+    l_retention_obj := l_config_obj.get_object('retention_days');
+
+    if l_retention_obj is null or not l_retention_obj.has(p_dataset) then
+      raise_application_error(-20014, 'missing or invalid retention_days.' || p_dataset);
+    end if;
+
+    l_retention_days := l_retention_obj.get_number(p_dataset);
+
+    if l_retention_days < 0 then
+      raise_application_error(-20013, 'retention_days.' || p_dataset || ' must be >= 0');
+    end if;
+
+    return l_retention_days;
+  exception
+    when value_error then
+      raise_application_error(-20014, 'missing or invalid retention_days.' || p_dataset);
+    when no_data_found then
+      raise_application_error(-20014, 'missing or invalid retention_days.' || p_dataset);
+    when others then
+      if sqlcode = -20013 then
+        raise;
+      end if;
+      raise_application_error(-20014, 'missing or invalid retention_days.' || p_dataset);
+  end resolve_retention_days;
+
+  function load_checkpoint(
+    p_config in clob
+  ) return timestamp with time zone
+  is
+    l_credential_name varchar2(128);
+    l_namespace varchar2(256);
+    l_bucket_name varchar2(256);
+    l_checkpoint_object varchar2(1024);
+    l_region varchar2(128);
+    l_uri varchar2(4000);
+    l_checkpoint_blob blob;
+    l_checkpoint_json clob;
+    l_timestamp_text varchar2(128);
+    l_loaded boolean := false;
+  begin
+    select json_value(p_config, '$.dbms_cloud_credential_name' returning varchar2(128) error on error),
+           json_value(p_config, '$.namespace' returning varchar2(256) error on error),
+           json_value(p_config, '$.bucket_name' returning varchar2(256) error on error),
+           json_value(p_config, '$.checkpoint_object' returning varchar2(1024) error on error)
+      into l_credential_name, l_namespace, l_bucket_name, l_checkpoint_object
+      from dual;
+
+    select coalesce(
+             json_value(p_config, '$.region' returning varchar2(128) null on error),
+             sys_context('USERENV', 'CLOUD_REGION')
+           )
+      into l_region
+      from dual;
+
+    if l_region is null then
+      return null;
+    end if;
+
+    l_uri := 'https://objectstorage.' || l_region || '.oraclecloud.com/n/'
+             || l_namespace || '/b/' || l_bucket_name || '/o/' || l_checkpoint_object;
+
+    begin
+      execute immediate
+        q'[begin
+              :result := dbms_cloud.get_object(
+                credential_name => :credential_name,
+                object_uri      => :object_uri
+              );
+            end;]'
+        using out l_checkpoint_blob, in l_credential_name, in l_uri;
+      l_checkpoint_json := blob_to_clob(l_checkpoint_blob);
+      l_loaded := true;
+    exception
+      when others then
+        if is_not_found_error(sqlcode) then
+          return null;
+        end if;
+    end;
+
+    if not l_loaded then
+      execute immediate
+        q'[begin
+              :result := dbms_cloud.get_object(
+                credential_name => :credential_name,
+                object_uri      => :object_uri
+              );
+            end;]'
+        using out l_checkpoint_json, in l_credential_name, in l_uri;
+    end if;
+
+    select json_value(
+             l_checkpoint_json,
+             '$.last_successful_run_at'
+             returning varchar2(128)
+             null on empty
+             error on error
+           )
+      into l_timestamp_text
+      from dual;
+
+    return parse_timestamp(l_timestamp_text);
+  exception
+    when others then
+      if is_not_found_error(sqlcode) then
+        return null;
+      end if;
+      raise;
+  end load_checkpoint;
+
+  function resolve_region(
+    p_config in clob
+  ) return varchar2
+  is
+    l_region varchar2(128);
+  begin
+    select coalesce(
+             json_value(p_config, '$.region' returning varchar2(128) null on error),
+             sys_context('USERENV', 'CLOUD_REGION')
+           )
+      into l_region
+      from dual;
+
+    return l_region;
+  end resolve_region;
+
+  function resolve_export_format(
+    p_config in clob
+  ) return varchar2
+  is
+    l_export_format varchar2(30);
+  begin
+    select lower(
+             coalesce(
+               json_value(p_config, '$.export_format' returning varchar2(30) null on error),
+               'parquet'
+             )
+           )
+      into l_export_format
+      from dual;
+
+    if l_export_format not in ('parquet', 'datapump') then
+      raise_application_error(-20024, 'unsupported export_format: ' || l_export_format);
+    end if;
+
+    return l_export_format;
+  end resolve_export_format;
+
+  procedure validate_export_request(
+    p_export_format in varchar2,
+    p_datasets      in t_dataset_list
+  )
+  is
+  begin
+    if p_export_format != 'datapump' then
+      return;
+    end if;
+
+    if p_datasets.count != 1 then
+      raise_application_error(-20026, 'datapump export format requires exactly one dataset per run');
+    end if;
+  end validate_export_request;
+
+  function trim_slashes(
+    p_value in varchar2
+  ) return varchar2
+  is
+  begin
+    return regexp_replace(nvl(trim(p_value), ''), '^/+|/+$', '');
+  end trim_slashes;
+
+  function build_object_uri(
+    p_region      in varchar2,
+    p_namespace   in varchar2,
+    p_bucket_name in varchar2,
+    p_object_name in varchar2
+  ) return varchar2
+  is
+  begin
+    return 'https://objectstorage.' || p_region || '.oraclecloud.com/n/'
+           || p_namespace || '/b/' || p_bucket_name || '/o/' || p_object_name;
+  end build_object_uri;
+
+  function build_run_id(
+    p_run_at in timestamp with time zone
+  ) return varchar2
+  is
+  begin
+    return to_char(p_run_at at time zone 'UTC', 'YYYYMMDD"T"HH24MISS"Z"');
+  end build_run_id;
+
+  function resolve_zone(
+    p_dataset in varchar2
+  ) return varchar2
+  is
+  begin
+    case p_dataset
+      when 'historized' then
+        return 'silver';
+      when 'raw' then
+        return 'bronze';
+      when 'rejected' then
+        return 'bronze';
+      else
+        raise_application_error(-20021, 'unsupported dataset for zone mapping: ' || p_dataset);
+    end case;
+  end resolve_zone;
+
+  function build_dataset_object_prefix(
+    p_prefix            in varchar2,
+    p_domain_short_name in varchar2,
+    p_dataset           in varchar2,
+    p_run_id            in varchar2,
+    p_run_at            in timestamp with time zone
+  ) return varchar2
+  is
+    l_prefix varchar2(1024);
+    l_run_at_utc timestamp with time zone;
+    l_zone varchar2(30);
+  begin
+    l_prefix := trim_slashes(p_prefix);
+    l_run_at_utc := p_run_at at time zone 'UTC';
+    l_zone := resolve_zone(p_dataset);
+    return l_prefix
+           || '/domain=' || p_domain_short_name
+           || '/zone=' || l_zone || '/dataset=' || p_dataset
+           || '/year=' || to_char(l_run_at_utc, 'YYYY')
+           || '/month=' || to_char(l_run_at_utc, 'MM')
+           || '/day=' || to_char(l_run_at_utc, 'DD')
+           || '/hour=' || to_char(l_run_at_utc, 'HH24')
+           || '/run_id=' || p_run_id;
+  end build_dataset_object_prefix;
+
+  function build_manifest_object_name(
+    p_manifest_prefix in varchar2,
+    p_run_id          in varchar2
+  ) return varchar2
+  is
+  begin
+    return trim_slashes(p_manifest_prefix) || '/run_id=' || p_run_id || '.json';
+  end build_manifest_object_name;
+
+  function to_sql_timestamp_tz_literal(
+    p_value in timestamp with time zone
+  ) return varchar2
+  is
+  begin
+    return 'to_timestamp_tz('''
+           || to_char(p_value at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')
+           || ''',''YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM'')';
+  end to_sql_timestamp_tz_literal;
+
+  function normalized_content_type_sql return varchar2
+  is
+  begin
+    return 'lower(trim(regexp_substr(content_type, ''^[^;]+'')))';
+  end normalized_content_type_sql;
+
+  function json_candidate_sql return varchar2
+  is
+  begin
+    return 'to_clob(utl_raw.cast_to_varchar2(dbms_lob.substr(content, 32767, 1)))';
+  end json_candidate_sql;
+
+  function content_encoding_sql return varchar2
+  is
+    l_content_type_expr varchar2(4000);
+    l_json_candidate_expr varchar2(4000);
+  begin
+    l_content_type_expr := normalized_content_type_sql();
+    l_json_candidate_expr := json_candidate_sql();
+    return 'case '
+           || 'when ' || l_content_type_expr || ' like ''text/%'' then ''text'' '
+           || 'when ' || l_content_type_expr || ' is null or instr(' || l_content_type_expr || ', ''json'') > 0 then '
+           || 'case when ' || l_json_candidate_expr || ' is json strict then ''json'' else ''base64'' end '
+           || 'else ''base64'' '
+           || 'end';
+  end content_encoding_sql;
+
+  function content_representation_sql return varchar2
+  is
+    l_content_type_expr varchar2(4000);
+    l_json_candidate_expr varchar2(4000);
+  begin
+    l_content_type_expr := normalized_content_type_sql();
+    l_json_candidate_expr := json_candidate_sql();
+    return 'case '
+           || 'when ' || l_content_type_expr || ' like ''text/%'' then ''json-string'' '
+           || 'when ' || l_content_type_expr || ' is null or instr(' || l_content_type_expr || ', ''json'') > 0 then '
+           || 'case when ' || l_json_candidate_expr || ' is json strict then ''parsed-json'' else ''base64-string'' end '
+           || 'else ''base64-string'' '
+           || 'end';
+  end content_representation_sql;
+
+  function build_raw_query(
+    p_domain_short_name in varchar2,
+    p_export_format     in varchar2,
+    p_window_start      in timestamp with time zone,
+    p_window_end        in timestamp with time zone
+  ) return clob
+  is
+    l_iot_schema varchar2(261);
+  begin
+    l_iot_schema := dbms_assert.simple_sql_name(
+      upper(trim(p_domain_short_name)) || '__IOT'
+    );
+
+    if p_export_format = 'datapump' then
+      return 'select * '
+             || 'from ' || l_iot_schema || '.raw_data '
+             || 'where time_received >= ' || to_sql_timestamp_tz_literal(p_window_start) || ' '
+             || 'and time_received < ' || to_sql_timestamp_tz_literal(p_window_end) || ' '
+             || 'order by time_received, id';
+    end if;
+
+    return 'select '
+           || 'id, digital_twin_instance_id, endpoint, time_received, content_type, '
+           || content_encoding_sql() || ' as content_encoding, '
+           || content_representation_sql() || ' as content_representation, '
+           || 'blob_to_json(content, content_type) as content '
+           || 'from ' || l_iot_schema || '.raw_data '
+           || 'where time_received >= ' || to_sql_timestamp_tz_literal(p_window_start) || ' '
+           || 'and time_received < ' || to_sql_timestamp_tz_literal(p_window_end) || ' '
+           || 'order by time_received, id';
+  end build_raw_query;
+
+  function build_historized_query(
+    p_domain_short_name in varchar2,
+    p_export_format     in varchar2,
+    p_window_start      in timestamp with time zone,
+    p_window_end        in timestamp with time zone
+  ) return clob
+  is
+    l_iot_schema varchar2(261);
+  begin
+    l_iot_schema := dbms_assert.simple_sql_name(
+      upper(trim(p_domain_short_name)) || '__IOT'
+    );
+
+    if p_export_format = 'datapump' then
+      return 'select * '
+             || 'from ' || l_iot_schema || '.historized_data '
+             || 'where time_observed >= ' || to_sql_timestamp_tz_literal(p_window_start) || ' '
+             || 'and time_observed < ' || to_sql_timestamp_tz_literal(p_window_end) || ' '
+             || 'order by time_observed, id';
+    end if;
+
+    return 'select '
+           || 'id, digital_twin_instance_id, content_path, time_observed, '
+           || 'json_serialize(value returning varchar2(32767)) as value_json, '
+           || 'json_value(value, ''$'' returning number null on error) as value_number, '
+           || 'json_value(value, ''$'' returning varchar2(32767) null on error) as value_text '
+           || 'from ' || l_iot_schema || '.historized_data '
+           || 'where time_observed >= ' || to_sql_timestamp_tz_literal(p_window_start) || ' '
+           || 'and time_observed < ' || to_sql_timestamp_tz_literal(p_window_end) || ' '
+           || 'order by time_observed, id';
+  end build_historized_query;
+
+  function build_rejected_query(
+    p_domain_short_name in varchar2,
+    p_export_format     in varchar2,
+    p_window_start      in timestamp with time zone,
+    p_window_end        in timestamp with time zone
+  ) return clob
+  is
+    l_iot_schema varchar2(261);
+  begin
+    l_iot_schema := dbms_assert.simple_sql_name(
+      upper(trim(p_domain_short_name)) || '__IOT'
+    );
+
+    if p_export_format = 'datapump' then
+      return 'select * '
+             || 'from ' || l_iot_schema || '.rejected_data '
+             || 'where time_received >= ' || to_sql_timestamp_tz_literal(p_window_start) || ' '
+             || 'and time_received < ' || to_sql_timestamp_tz_literal(p_window_end) || ' '
+             || 'order by time_received, id';
+    end if;
+
+    return 'select '
+           || 'id, digital_twin_instance_id, endpoint, time_received, '
+           || 'reason_code, reason_message, content_type, '
+           || content_encoding_sql() || ' as content_encoding, '
+           || content_representation_sql() || ' as content_representation, '
+           || 'blob_to_json(content, content_type) as content '
+           || 'from ' || l_iot_schema || '.rejected_data '
+           || 'where time_received >= ' || to_sql_timestamp_tz_literal(p_window_start) || ' '
+           || 'and time_received < ' || to_sql_timestamp_tz_literal(p_window_end) || ' '
+           || 'order by time_received, id';
+  end build_rejected_query;
+
+  procedure put_json_object(
+    p_credential_name in varchar2,
+    p_object_uri      in varchar2,
+    p_payload         in clob
+  )
+  is
+    l_payload_blob blob;
+  begin
+    l_payload_blob := clob_to_blob(p_payload);
+
+    dbms_cloud.put_object(
+      credential_name => p_credential_name,
+      object_uri      => p_object_uri,
+      contents        => l_payload_blob
+    );
+  end put_json_object;
+
+  procedure plan(
+    p_config_name  in varchar2 default 'default',
+    p_dataset_list in varchar2 default 'raw,historized,rejected',
+    p_start_time   in timestamp with time zone default null,
+    p_end_time     in timestamp with time zone default null,
+    p_result       out clob
+  )
+  is
+    l_config clob;
+    l_now timestamp with time zone := systimestamp;
+    l_checkpoint_before timestamp with time zone;
+    l_bootstrap_lookback_days pls_integer;
+    l_datasets t_dataset_list;
+    l_result_obj json_object_t := json_object_t();
+    l_datasets_obj json_object_t := json_object_t();
+    l_dataset_obj json_object_t;
+    l_dataset varchar2(30);
+    l_export_format varchar2(30);
+    l_retention_days pls_integer;
+    l_purge_boundary timestamp with time zone;
+    l_window_start timestamp with time zone;
+    l_window_end timestamp with time zone;
+  begin
+    l_config := load_config(p_config_name => p_config_name);
+    l_datasets := parse_datasets(p_dataset_list => p_dataset_list);
+    l_export_format := resolve_export_format(p_config => l_config);
+    validate_export_request(
+      p_export_format => l_export_format,
+      p_datasets      => l_datasets
+    );
+    l_checkpoint_before := load_checkpoint(p_config => l_config);
+
+    begin
+      select json_value(
+               l_config,
+               '$.bootstrap_lookback_days'
+               returning number
+               error on error
+             )
+        into l_bootstrap_lookback_days
+        from dual;
+    exception
+      when others then
+        raise_application_error(-20017, 'missing or invalid bootstrap_lookback_days');
+    end;
+
+    if l_bootstrap_lookback_days < 0 then
+      raise_application_error(-20016, 'bootstrap_lookback_days must be >= 0');
+    end if;
+
+    l_result_obj.put('now', format_timestamp(l_now));
+    l_result_obj.put('export_format', l_export_format);
+    if l_checkpoint_before is null then
+      l_result_obj.put_null('checkpoint_before');
+    else
+      l_result_obj.put('checkpoint_before', format_timestamp(l_checkpoint_before));
+    end if;
+
+    for l_index in 1 .. l_datasets.count loop
+      l_dataset := l_datasets(l_index);
+      l_retention_days := resolve_retention_days(
+        p_config  => l_config,
+        p_dataset => l_dataset
+      );
+      l_purge_boundary := l_now - numtodsinterval(l_retention_days, 'DAY');
+      l_window_end := coalesce(p_end_time, l_purge_boundary);
+
+      if p_start_time is not null then
+        l_window_start := p_start_time;
+      elsif l_checkpoint_before is not null then
+        l_window_start := l_checkpoint_before - numtodsinterval(l_retention_days, 'DAY');
+      else
+        l_window_start := l_purge_boundary - numtodsinterval(l_bootstrap_lookback_days, 'DAY');
+      end if;
+
+      l_dataset_obj := json_object_t();
+      l_dataset_obj.put('retention_days', l_retention_days);
+      l_dataset_obj.put('purge_boundary', format_timestamp(l_purge_boundary));
+      l_dataset_obj.put('window_start', format_timestamp(l_window_start));
+      l_dataset_obj.put('window_end', format_timestamp(l_window_end));
+      l_datasets_obj.put(l_dataset, l_dataset_obj);
+    end loop;
+
+    l_result_obj.put('datasets', l_datasets_obj);
+    p_result := l_result_obj.to_clob();
+  end plan;
+
+  procedure run(
+    p_config_name  in varchar2 default 'default',
+    p_dataset_list in varchar2 default 'raw,historized,rejected',
+    p_start_time   in timestamp with time zone default null,
+    p_end_time     in timestamp with time zone default null,
+    p_result       out clob
+  )
+  is
+    l_config clob;
+    l_datasets t_dataset_list;
+    l_plan_result clob;
+    l_plan_obj json_object_t;
+    l_plan_datasets_obj json_object_t;
+    l_plan_dataset_obj json_object_t;
+    l_checkpoint_before_element json_element_t;
+    l_run_at timestamp with time zone;
+    l_window_start timestamp with time zone;
+    l_window_end timestamp with time zone;
+    l_region varchar2(128);
+    l_domain_short_name varchar2(128);
+    l_namespace varchar2(256);
+    l_bucket_name varchar2(256);
+    l_prefix varchar2(1024);
+    l_manifest_prefix varchar2(1024);
+    l_checkpoint_object varchar2(1024);
+    l_credential_name varchar2(128);
+    l_checkpoint_before varchar2(128);
+    l_dataset varchar2(30);
+    l_run_id varchar2(64);
+    l_dataset_object_prefix varchar2(2048);
+    l_dataset_file_uri_list varchar2(4000);
+    l_dataset_query clob;
+    l_dataset_export_format varchar2(30);
+    l_dataset_status varchar2(32);
+    l_dataset_error_message varchar2(4000);
+    l_all_succeeded boolean := true;
+    l_selected_datasets json_array_t := json_array_t();
+    l_manifest_dataset_results json_array_t := json_array_t();
+    l_result_datasets_obj json_object_t := json_object_t();
+    l_manifest_dataset_obj json_object_t;
+    l_result_dataset_obj json_object_t;
+    l_manifest_obj json_object_t := json_object_t();
+    l_result_obj json_object_t := json_object_t();
+    l_manifest_object_name varchar2(2048);
+    l_manifest_uri varchar2(4000);
+    l_manifest_json clob;
+    l_checkpoint_uri varchar2(4000);
+    l_checkpoint_json clob;
+    l_export_format varchar2(30);
+  begin
+    l_config := load_config(p_config_name => p_config_name);
+    l_datasets := parse_datasets(p_dataset_list => p_dataset_list);
+
+    plan(
+      p_config_name  => p_config_name,
+      p_dataset_list => p_dataset_list,
+      p_start_time   => p_start_time,
+      p_end_time     => p_end_time,
+      p_result       => l_plan_result
+    );
+
+    l_plan_obj := json_object_t.parse(l_plan_result);
+    l_run_at := parse_timestamp(l_plan_obj.get_string('now'));
+    l_export_format := l_plan_obj.get_string('export_format');
+    l_plan_datasets_obj := l_plan_obj.get_object('datasets');
+    l_checkpoint_before_element := l_plan_obj.get('checkpoint_before');
+    if l_checkpoint_before_element is not null and not l_checkpoint_before_element.is_null then
+      l_checkpoint_before := l_plan_obj.get_string('checkpoint_before');
+    end if;
+
+    select json_value(l_config, '$.domain_short_name' returning varchar2(128) error on error),
+           json_value(l_config, '$.namespace' returning varchar2(256) error on error),
+           json_value(l_config, '$.bucket_name' returning varchar2(256) error on error),
+           json_value(l_config, '$.prefix' returning varchar2(1024) error on error),
+           json_value(l_config, '$.manifest_prefix' returning varchar2(1024) error on error),
+           json_value(l_config, '$.checkpoint_object' returning varchar2(1024) error on error),
+           json_value(l_config, '$.dbms_cloud_credential_name' returning varchar2(128) error on error)
+      into l_domain_short_name, l_namespace, l_bucket_name, l_prefix, l_manifest_prefix,
+           l_checkpoint_object, l_credential_name
+      from dual;
+
+    l_region := resolve_region(l_config);
+    if l_region is null then
+      raise_application_error(-20020, 'missing region and CLOUD_REGION context');
+    end if;
+
+    l_run_id := build_run_id(l_run_at);
+    for l_index in 1 .. l_datasets.count loop
+      l_dataset := l_datasets(l_index);
+      l_selected_datasets.append(l_dataset);
+
+      l_plan_dataset_obj := l_plan_datasets_obj.get_object(l_dataset);
+      l_window_start := parse_timestamp(l_plan_dataset_obj.get_string('window_start'));
+      l_window_end := parse_timestamp(l_plan_dataset_obj.get_string('window_end'));
+
+      l_dataset_object_prefix := build_dataset_object_prefix(
+        p_prefix            => l_prefix,
+        p_domain_short_name => l_domain_short_name,
+        p_dataset           => l_dataset,
+        p_run_id            => l_run_id,
+        p_run_at            => l_run_at
+      );
+
+      case l_dataset
+        when 'raw' then
+          l_dataset_query := build_raw_query(
+            p_domain_short_name => l_domain_short_name,
+            p_export_format     => l_export_format,
+            p_window_start      => l_window_start,
+            p_window_end        => l_window_end
+          );
+          l_dataset_export_format := l_export_format;
+          if l_export_format = 'datapump' then
+            l_dataset_file_uri_list := build_object_uri(
+              p_region      => l_region,
+              p_namespace   => l_namespace,
+              p_bucket_name => l_bucket_name,
+              p_object_name => l_dataset_object_prefix || '/raw_01.dmp'
+            );
+          else
+            l_dataset_file_uri_list := build_object_uri(
+              p_region      => l_region,
+              p_namespace   => l_namespace,
+              p_bucket_name => l_bucket_name,
+              p_object_name => l_dataset_object_prefix || '/' || l_dataset
+            );
+          end if;
+        when 'historized' then
+          l_dataset_query := build_historized_query(
+            p_domain_short_name => l_domain_short_name,
+            p_export_format     => l_export_format,
+            p_window_start      => l_window_start,
+            p_window_end        => l_window_end
+          );
+          l_dataset_export_format := l_export_format;
+          if l_export_format = 'datapump' then
+            l_dataset_file_uri_list := build_object_uri(
+              p_region      => l_region,
+              p_namespace   => l_namespace,
+              p_bucket_name => l_bucket_name,
+              p_object_name => l_dataset_object_prefix || '/historized_01.dmp'
+            );
+          else
+            l_dataset_file_uri_list := build_object_uri(
+              p_region      => l_region,
+              p_namespace   => l_namespace,
+              p_bucket_name => l_bucket_name,
+              p_object_name => l_dataset_object_prefix || '/' || l_dataset
+            );
+          end if;
+        when 'rejected' then
+          l_dataset_query := build_rejected_query(
+            p_domain_short_name => l_domain_short_name,
+            p_export_format     => l_export_format,
+            p_window_start      => l_window_start,
+            p_window_end        => l_window_end
+          );
+          l_dataset_export_format := l_export_format;
+          if l_export_format = 'datapump' then
+            l_dataset_file_uri_list := build_object_uri(
+              p_region      => l_region,
+              p_namespace   => l_namespace,
+              p_bucket_name => l_bucket_name,
+              p_object_name => l_dataset_object_prefix || '/rejected_01.dmp'
+            );
+          else
+            l_dataset_file_uri_list := build_object_uri(
+              p_region      => l_region,
+              p_namespace   => l_namespace,
+              p_bucket_name => l_bucket_name,
+              p_object_name => l_dataset_object_prefix || '/' || l_dataset
+            );
+          end if;
+      end case;
+
+      l_dataset_status := 'planned';
+      l_dataset_error_message := null;
+
+      begin
+        if l_dataset_export_format = 'datapump' then
+          dbms_cloud.export_data(
+            credential_name => l_credential_name,
+            file_uri_list   => l_dataset_file_uri_list,
+            format          => json_object(
+                                 'type' value 'datapump',
+                                 'compression' value 'HIGH',
+                                 'version' value 'LATEST'
+                               ),
+            query           => l_dataset_query
+          );
+        else
+          dbms_cloud.export_data(
+            credential_name => l_credential_name,
+            file_uri_list   => l_dataset_file_uri_list,
+            format          => '{"type":"' || l_dataset_export_format || '"}',
+            query           => l_dataset_query
+          );
+        end if;
+        l_dataset_status := 'succeeded';
+      exception
+        when others then
+          l_dataset_status := 'failed';
+          l_dataset_error_message := substr(sqlerrm, 1, 4000);
+      end;
+
+      if l_dataset_status <> 'succeeded' then
+        l_all_succeeded := false;
+      end if;
+
+      l_manifest_dataset_obj := json_object_t();
+      l_manifest_dataset_obj.put('name', l_dataset);
+      l_manifest_dataset_obj.put('status', l_dataset_status);
+      l_manifest_dataset_obj.put('export_mode', 'bulk');
+      l_manifest_dataset_obj.put('export_format', l_dataset_export_format);
+      l_manifest_dataset_obj.put('object_prefix', l_dataset_object_prefix);
+      if l_dataset_error_message is null then
+        l_manifest_dataset_obj.put_null('error_message');
+      else
+        l_manifest_dataset_obj.put('error_message', l_dataset_error_message);
+      end if;
+      l_manifest_dataset_results.append(l_manifest_dataset_obj);
+
+      l_result_dataset_obj := json_object_t();
+      l_result_dataset_obj.put('status', l_dataset_status);
+      l_result_dataset_obj.put('export_format', l_dataset_export_format);
+      l_result_dataset_obj.put('object_prefix', l_dataset_object_prefix);
+      l_result_dataset_obj.put('file_uri_list', l_dataset_file_uri_list);
+      if l_dataset_error_message is null then
+        l_result_dataset_obj.put_null('error_message');
+      else
+        l_result_dataset_obj.put('error_message', l_dataset_error_message);
+      end if;
+      l_result_datasets_obj.put(l_dataset, l_result_dataset_obj);
+    end loop;
+
+    l_manifest_object_name := build_manifest_object_name(
+      p_manifest_prefix => l_manifest_prefix,
+      p_run_id          => l_run_id
+    );
+    l_manifest_uri := build_object_uri(
+      p_region      => l_region,
+      p_namespace   => l_namespace,
+      p_bucket_name => l_bucket_name,
+      p_object_name => l_manifest_object_name
+    );
+
+    l_manifest_obj.put('run_id', l_run_id);
+    l_manifest_obj.put('selected_datasets', l_selected_datasets);
+    if l_checkpoint_before is null then
+      l_manifest_obj.put_null('checkpoint_before');
+    else
+      l_manifest_obj.put('checkpoint_before', l_checkpoint_before);
+    end if;
+    l_manifest_obj.put('dataset_results', l_manifest_dataset_results);
+    l_manifest_json := l_manifest_obj.to_clob();
+
+    put_json_object(
+      p_credential_name => l_credential_name,
+      p_object_uri      => l_manifest_uri,
+      p_payload         => l_manifest_json
+    );
+
+    if l_all_succeeded then
+      l_checkpoint_uri := build_object_uri(
+        p_region      => l_region,
+        p_namespace   => l_namespace,
+        p_bucket_name => l_bucket_name,
+        p_object_name => l_checkpoint_object
+      );
+
+      l_result_dataset_obj := json_object_t();
+      l_result_dataset_obj.put('last_successful_run_at', format_timestamp(l_run_at));
+      l_checkpoint_json := l_result_dataset_obj.to_clob();
+
+      put_json_object(
+        p_credential_name => l_credential_name,
+        p_object_uri      => l_checkpoint_uri,
+        p_payload         => l_checkpoint_json
+      );
+    end if;
+
+    l_result_obj.put('run_id', l_run_id);
+    l_result_obj.put('export_format', l_export_format);
+    l_result_obj.put('datasets', l_result_datasets_obj);
+    l_result_obj.put('manifest_object_name', l_manifest_object_name);
+    l_result_obj.put('checkpoint_advanced', l_all_succeeded);
+    p_result := l_result_obj.to_clob();
+  end run;
+end archive_domain_pkg;
+/
+
+show errors
+
+declare
+  l_error_count number;
+begin
+  select count(*)
+    into l_error_count
+    from user_errors
+   where name = 'ARCHIVE_DOMAIN_PKG'
+     and type = 'PACKAGE BODY';
+
+  if l_error_count > 0 then
+    raise_application_error(-20001, 'archive_domain_pkg body compilation failed');
+  end if;
+end;
+/

--- a/samples/sql/archive-domain/archive_domain_tables.sql
+++ b/samples/sql/archive-domain/archive_domain_tables.sql
@@ -1,0 +1,48 @@
+--
+-- Table definitions for the SQL archive-domain sample.
+--
+-- Copyright (c) 2026 Oracle and/or its affiliates.
+-- Licensed under the Universal Permissive License v 1.0 as shown at
+-- https://oss.oracle.com/licenses/upl.
+--
+-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+--
+
+whenever sqlerror exit sql.sqlcode
+
+create table archive_domain_config
+(
+  config_name varchar2(128) not null,
+  config_json clob not null check (config_json is json),
+  created_at  timestamp with time zone default systimestamp not null,
+  updated_at  timestamp with time zone default systimestamp not null,
+  constraint archive_domain_config_pk primary key (config_name)
+);
+
+create or replace trigger archive_domain_config_ts
+before insert or update on archive_domain_config
+for each row
+begin
+  if inserting then
+    :new.created_at := systimestamp;
+  end if;
+  :new.updated_at := systimestamp;
+end;
+/
+
+show errors;
+
+declare
+  l_error_count number;
+begin
+  select count(*)
+    into l_error_count
+    from user_errors
+   where name = 'ARCHIVE_DOMAIN_CONFIG_TS'
+     and type = 'TRIGGER';
+
+  if l_error_count > 0 then
+    raise_application_error(-20002, 'archive_domain_config_ts compilation failed');
+  end if;
+end;
+/

--- a/samples/sql/archive-domain/data/archive_config.distr.json
+++ b/samples/sql/archive-domain/data/archive_config.distr.json
@@ -1,0 +1,18 @@
+{
+  "export_format": "parquet",
+  "domain_id": "<IoT Domain OCID>",
+  "domain_short_name": "<Domain Short Name>",
+  "namespace": "<Object Storage Namespace>",
+  "bucket_name": "<Bucket Name>",
+  "prefix": "iot-archive-sql",
+  "manifest_prefix": "iot-archive-sql/_manifests",
+  "checkpoint_object": "iot-archive-sql/_state/checkpoint.json",
+  "dbms_cloud_credential_name": "DOMAIN_ARCHIVE_TEST",
+  "bootstrap_lookback_days": 1,
+  "region": "us-phoenix-1",
+  "retention_days": {
+    "raw": 16,
+    "historized": 30,
+    "rejected": 16
+  }
+}

--- a/samples/sql/archive-domain/install.sql
+++ b/samples/sql/archive-domain/install.sql
@@ -1,0 +1,17 @@
+--
+-- Install the supporting objects for the SQL archive-domain sample.
+--
+-- Copyright (c) 2026 Oracle and/or its affiliates.
+-- Licensed under the Universal Permissive License v 1.0 as shown at
+-- https://oss.oracle.com/licenses/upl.
+--
+-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+--
+
+whenever sqlerror exit sql.sqlcode
+
+prompt Creating archive_domain_config table
+@@archive_domain_tables.sql
+
+prompt Creating archive_domain_pkg
+@@archive_domain_pkg.sql

--- a/samples/sql/archive-domain/load_config.py
+++ b/samples/sql/archive-domain/load_config.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Load archive-domain JSON configuration into archive_domain_config.
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at
+https://oss.oracle.com/licenses/upl
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import oracledb
+import oracledb.plugins.oci_tokens  # noqa: F401
+
+
+def build_dsn(connect_string: str) -> str:
+    """Convert the IoT DB connect string into an Oracle DSN."""
+    match = re.match(r"tcps:(.*):(\d+)/([^?]*)(\?.*)?", connect_string)
+    if not match:
+        raise ValueError("Invalid connect string")
+
+    hostname, port, service, _ = match.groups()
+    return f"""
+        (DESCRIPTION =
+            (ADDRESS=(PROTOCOL=TCPS)(PORT={port})(HOST={hostname}))
+            (CONNECT_DATA=(SERVICE_NAME={service}))
+        )"""
+
+
+def connect(args: argparse.Namespace):
+    """Connect to the workspace schema using OCI token-based auth."""
+    extra_auth_params = {
+        "auth_type": args.auth_type,
+        "scope": args.token_scope,
+    }
+    if args.auth_type == "ConfigFileAuthentication":
+        extra_auth_params["profile"] = args.profile
+
+    return oracledb.connect(
+        dsn=build_dsn(args.connect_string),
+        proxy_user=args.proxy_user,
+        extra_auth_params=extra_auth_params,
+    )
+
+
+def load_json_file(path: Path) -> str:
+    """Load and validate the JSON config payload."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return json.dumps(payload, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Load archive-domain JSON config into archive_domain_config."
+    )
+    parser.add_argument(
+        "--config-file",
+        required=True,
+        type=Path,
+        help="Path to archive_config.json.",
+    )
+    parser.add_argument(
+        "--config-name",
+        default="default",
+        help="Logical config_name value in archive_domain_config.",
+    )
+    parser.add_argument(
+        "--proxy-user",
+        required=True,
+        help="Workspace proxy user such as KBCB5B66BKIW6__WKSP.",
+    )
+    parser.add_argument(
+        "--connect-string",
+        required=True,
+        help="IoT DB connect string in tcps:host:port/service form.",
+    )
+    parser.add_argument(
+        "--token-scope",
+        required=True,
+        help="OCI IAM DB token scope for the IoT domain group.",
+    )
+    parser.add_argument(
+        "--auth-type",
+        choices=["InstancePrincipal", "ConfigFileAuthentication"],
+        default="InstancePrincipal",
+        help="Token-auth mode to use for the database connection.",
+    )
+    parser.add_argument(
+        "--profile",
+        default="DEFAULT",
+        help="OCI profile used when auth-type is ConfigFileAuthentication.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Upsert the JSON payload into archive_domain_config."""
+    args = parse_args()
+    config_json = load_json_file(args.config_file)
+
+    with connect(args) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "delete from archive_domain_config where config_name = :config_name",
+                config_name=args.config_name,
+            )
+            cur.execute(
+                """
+                insert into archive_domain_config(config_name, config_json)
+                values (:config_name, :config_json)
+                """,
+                config_name=args.config_name,
+                config_json=config_json,
+            )
+        conn.commit()
+
+    print(f"loaded config '{args.config_name}' from {args.config_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sql/archive-domain/teardown.sql
+++ b/samples/sql/archive-domain/teardown.sql
@@ -1,0 +1,56 @@
+--
+-- Remove supporting objects for the SQL archive-domain sample.
+--
+-- Copyright (c) 2026 Oracle and/or its affiliates.
+-- Licensed under the Universal Permissive License v 1.0 as shown at
+-- https://oss.oracle.com/licenses/upl.
+--
+-- DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+--
+
+whenever sqlerror exit sql.sqlcode
+
+declare
+  l_package_exists number;
+begin
+  select count(*)
+    into l_package_exists
+    from user_objects
+   where object_name = 'ARCHIVE_DOMAIN_PKG'
+     and object_type in ('PACKAGE', 'PACKAGE BODY');
+
+  if l_package_exists > 0 then
+    execute immediate 'drop package archive_domain_pkg';
+  end if;
+end;
+/
+
+declare
+  l_trigger_exists number;
+begin
+  select count(*)
+    into l_trigger_exists
+    from user_objects
+   where object_name = 'ARCHIVE_DOMAIN_CONFIG_TS'
+     and object_type = 'TRIGGER';
+
+  if l_trigger_exists > 0 then
+    execute immediate 'drop trigger archive_domain_config_ts';
+  end if;
+end;
+/
+
+declare
+  l_table_exists number;
+begin
+  select count(*)
+    into l_table_exists
+    from user_objects
+   where object_name = 'ARCHIVE_DOMAIN_CONFIG'
+     and object_type = 'TABLE';
+
+  if l_table_exists > 0 then
+    execute immediate 'drop table archive_domain_config';
+  end if;
+end;
+/


### PR DESCRIPTION
## Summary

Adds the archive-domain sample for exporting OCI IoT domain data from Autonomous Database to Object Storage.

The sample includes:

- Python archiver support for Parquet and Oracle Data Pump export formats.
- SQL package support for config-driven archive runs.
- Use of the public `blob_to_json(content, content_type)` API.
- Documentation for archive configuration, export format selection, and retention-window behavior.
- Data Pump export support enabled now that the database capability is available.
- Removal of unpublished SQL smoke-test scripts since the READMEs do not document a smoke-test workflow.

## Validation

- `python -m pytest samples/python/archive-domain/tests -q`
- `python -m compileall samples/python/archive-domain`
- `python -m ruff check samples/python/archive-domain`
- `git diff --check`

Manual live validation was also run against the IoT ADB path for both Parquet and Data Pump archive exports.